### PR TITLE
chore: remove unneeded lint disabling

### DIFF
--- a/__tests__/env_browser/adapter/clickAt.ts
+++ b/__tests__/env_browser/adapter/clickAt.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {DullahanAdapter, AdapterError, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/clickAtElement.ts
+++ b/__tests__/env_browser/adapter/clickAtElement.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/clickAtElementCenter.ts
+++ b/__tests__/env_browser/adapter/clickAtElementCenter.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/closeBrowser.ts
+++ b/__tests__/env_browser/adapter/closeBrowser.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {DullahanAdapter, AdapterError, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/displayPointer.ts
+++ b/__tests__/env_browser/adapter/displayPointer.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/getElementAttributes.ts
+++ b/__tests__/env_browser/adapter/getElementAttributes.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/getElementProperties.ts
+++ b/__tests__/env_browser/adapter/getElementProperties.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/getElementStyles.ts
+++ b/__tests__/env_browser/adapter/getElementStyles.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/getURL.ts
+++ b/__tests__/env_browser/adapter/getURL.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/isBrowserOpen.ts
+++ b/__tests__/env_browser/adapter/isBrowserOpen.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {DullahanAdapter, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/isElementPresent.ts
+++ b/__tests__/env_browser/adapter/isElementPresent.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {DullahanAdapter, AdapterError, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/isElementVisible.ts
+++ b/__tests__/env_browser/adapter/isElementVisible.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {DullahanAdapter, AdapterError, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/moveMouseTo.ts
+++ b/__tests__/env_browser/adapter/moveMouseTo.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {DullahanAdapter, AdapterError, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/moveMouseToElement.ts
+++ b/__tests__/env_browser/adapter/moveMouseToElement.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/moveMouseToElementCenter.ts
+++ b/__tests__/env_browser/adapter/moveMouseToElementCenter.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/openBrowser.ts
+++ b/__tests__/env_browser/adapter/openBrowser.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {DullahanAdapter, AdapterError, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/pressMouseAt.ts
+++ b/__tests__/env_browser/adapter/pressMouseAt.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {DullahanAdapter, AdapterError, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/releaseMouseAt.ts
+++ b/__tests__/env_browser/adapter/releaseMouseAt.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {DullahanAdapter, AdapterError, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/screenshotPage.ts
+++ b/__tests__/env_browser/adapter/screenshotPage.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/scrollToElement.ts
+++ b/__tests__/env_browser/adapter/scrollToElement.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/setURL.ts
+++ b/__tests__/env_browser/adapter/setURL.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/waitForElementPresent.ts
+++ b/__tests__/env_browser/adapter/waitForElementPresent.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/adapter/waitForElementVisible.ts
+++ b/__tests__/env_browser/adapter/waitForElementVisible.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {AdapterError, DullahanAdapter, DullahanErrorMessage, tryX} from "@k2g/dullahan";
 
 declare const adapter: DullahanAdapter<never, never>;

--- a/__tests__/env_browser/api/constructor.ts
+++ b/__tests__/env_browser/api/constructor.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {DullahanApi, DullahanAdapter} from "@k2g/dullahan";
 
 declare const api: DullahanApi<never, never>;

--- a/__tests__/env_browser/api/getText.ts
+++ b/__tests__/env_browser/api/getText.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  */
-
 import {DullahanApi, AdapterError, DullahanErrorMessage, DullahanAdapter} from "@k2g/dullahan";
 
 declare const api: DullahanApi<never, never>;

--- a/packages/dullahan-plugin-aws-s3/src/DullahanPluginAwsS3.ts
+++ b/packages/dullahan-plugin-aws-s3/src/DullahanPluginAwsS3.ts
@@ -47,13 +47,13 @@ export default class DullahanPluginAwsS3 extends DullahanPlugin<
         }
     }
 
-    private getSecretRegex(secret: string | RegExp) {
+    private getRegexForSecret(secret: string | RegExp): RegExp {
         if (secret instanceof RegExp)    {
             return secret;
         }
         const secretRegex = /\/(.+)\//.exec(secret);
-        return secretRegex !== null ?
-            new RegExp(secretRegex[1], 'gim')
+        return secretRegex !== null
+            ? new RegExp(secretRegex[1], 'gim')
             : new RegExp(secret.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'), 'gim');
     }
 
@@ -75,7 +75,7 @@ export default class DullahanPluginAwsS3 extends DullahanPlugin<
                 .map(([, value]) => value)
         ])].forEach((secret) => {
             if (secret) {
-                const searchValue = this.getSecretRegex(secret);
+                const searchValue = this.getRegexForSecret(secret);
                 safeData = safeData.replace(searchValue, '<secret>');
             }
         });

--- a/packages/dullahan/__tests__/AdapterError.ts
+++ b/packages/dullahan/__tests__/AdapterError.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 import {AdapterError} from '@k2g/dullahan';
 
 describe('AdapterError', () => {

--- a/packages/dullahan/__tests__/AssertionError.ts
+++ b/packages/dullahan/__tests__/AssertionError.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 import {AssertionError} from '@k2g/dullahan';
 
 describe('AdapterError', () => {

--- a/packages/dullahan/src/browser_helpers/displayPointer.ts
+++ b/packages/dullahan/src/browser_helpers/displayPointer.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 declare global {
     interface Window {
         __DULLAHAN_POINTER_ENABLED__?: boolean;

--- a/packages/dullahan/src/browser_helpers/emitFakeEvent.ts
+++ b/packages/dullahan/src/browser_helpers/emitFakeEvent.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 type MouseEvents = 'mousedown' | 'mouseup' | 'click' | 'mousemove';
 
 export type EmitFakeEventOptions = {

--- a/packages/dullahan/src/browser_helpers/findElement.ts
+++ b/packages/dullahan/src/browser_helpers/findElement.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 declare global {
     interface Element {
         computedStyleMap: undefined | (() => Map<string, {

--- a/packages/dullahan/src/browser_helpers/getBoundingClientRect.ts
+++ b/packages/dullahan/src/browser_helpers/getBoundingClientRect.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 export function getBoundingClientRect(this: void, element: Element): {
     top: number;
     left: number;

--- a/packages/dullahan/src/browser_helpers/getElementAttributes.ts
+++ b/packages/dullahan/src/browser_helpers/getElementAttributes.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 export type GetElementAttributesOptions = {
     element: Element;
     attributeNames: string[]

--- a/packages/dullahan/src/browser_helpers/getElementProperties.ts
+++ b/packages/dullahan/src/browser_helpers/getElementProperties.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 export type GetElementPropertiesOptions = {
     element: Element;
     propertyNames: string[]

--- a/packages/dullahan/src/browser_helpers/getElementStyles.ts
+++ b/packages/dullahan/src/browser_helpers/getElementStyles.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 declare global {
     interface Element {
         computedStyleMap: undefined | (() => Map<string, {

--- a/packages/dullahan/src/browser_helpers/scrollToElement.ts
+++ b/packages/dullahan/src/browser_helpers/scrollToElement.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 export function scrollToElement(this: void, element: Element): void {
     element.scrollIntoView({
         behavior: 'auto',

--- a/packages/dullahan/src/browser_helpers/setElementAttribute.ts
+++ b/packages/dullahan/src/browser_helpers/setElementAttribute.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 export type SetElementAttributeOptions = {
     element: Element;
     attributeName: string;

--- a/packages/dullahan/src/browser_helpers/setElementProperty.ts
+++ b/packages/dullahan/src/browser_helpers/setElementProperty.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 export type SetElementPropertyOptions = {
     element: Element;
     propertyName: string;

--- a/packages/dullahan/src/browser_helpers/waitForReadyState.ts
+++ b/packages/dullahan/src/browser_helpers/waitForReadyState.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 export type DullahanReadyState = 'loading' | 'interactive' | 'complete'
 
 export type WaitForReadyStateOptions = {
@@ -17,7 +15,7 @@ export function waitForReadyState(this: void, options: WaitForReadyStateOptions)
     var timeout = options.timeout;
     var interval = Math.floor(timeout / 100);
     var endTime = Date.now() + timeout;
-    
+
     function performSearch(): boolean {
         try {
             return states[document.readyState] >= wantedState;
@@ -30,7 +28,7 @@ export function waitForReadyState(this: void, options: WaitForReadyStateOptions)
         return new Promise(function poll(resolve, reject) {
             try {
                 var result = performSearch();
-    
+
                 if (result) {
                      resolve(result);
                 } else if (Date.now() < endTime) {


### PR DESCRIPTION
This PR enables eslint again for a lot of files. Linting was disabled for these files, but there are no linting errors, so it served no purpose.