### PR TITLE
chore: add the option to append a custom user agent in puppeteer

### DIFF
--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
@@ -750,7 +750,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
         sessionId: string | null
     }> {
         const {options} = this;
-        const {headless, browserName, emulateDevice} = options;
+        const {headless, browserName, emulateDevice, userAgent} = options;
 
         if (this.browser) {
             throw new AdapterError(DullahanErrorMessage.ACTIVE_BROWSER);
@@ -768,7 +768,14 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
         const page = pages[pages.length - 1];
 
         if (emulateDevice) {
-            await page.emulate(Puppeteer.devices[emulateDevice]);
+            const emulationTarget = Puppeteer.devices[emulateDevice];
+            if (userAgent) {
+                emulationTarget.userAgent += ` ${userAgent}`;
+            }
+            await page.emulate(emulationTarget);
+        } else if (userAgent) {
+            const defaultUserAgent = await browser.userAgent();
+            await page.setUserAgent(`${defaultUserAgent} ${userAgent}`);
         }
 
         this.browser = browser;

--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteerOptions.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteerOptions.ts
@@ -3,6 +3,7 @@ import {DullahanAdapterUserOptions, DullahanAdapterDefaultOptions} from '@k2g/du
 export type DullahanAdapterPuppeteerUserOptions = Partial<DullahanAdapterUserOptions & {
     browserName?: 'chrome' | 'firefox';
     emulateDevice?: string;
+    userAgent?: string;
  }>;
 
 export const DullahanAdapterPuppeteerDefaultOptions = {


### PR DESCRIPTION
This adds the option to provide a `userAgent` to the `dullahan-puppeteer-plugin`. It will be appended to the actual `user agent`.