### PR TITLE
chore: update testdata in lambda runner and add useAccessKeys property

### DIFF
--- a/__snapshots__/env_nodejs/exports.ts.snap
+++ b/__snapshots__/env_nodejs/exports.ts.snap
@@ -273,6 +273,7 @@ Object {
   "slaveOptions": Object {},
   "slaveQualifier": undefined,
   "testPredicate": [Function],
+  "useAccessKeys": true
 }
 `;
 

--- a/__snapshots__/env_nodejs/exports.ts.snap
+++ b/__snapshots__/env_nodejs/exports.ts.snap
@@ -273,7 +273,7 @@ Object {
   "slaveOptions": Object {},
   "slaveQualifier": undefined,
   "testPredicate": [Function],
-  "useAccessKeys": true
+  "useAccessKeys": true,
 }
 `;
 

--- a/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambdaOptions.ts
+++ b/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambdaOptions.ts
@@ -20,6 +20,7 @@ export type DullahanRunnerAwsLambdaUserOptions = Partial<DullahanRunnerUserOptio
         file: string;
         [key: string]: unknown;
     };
+    useAccessKeys: boolean;
 }>;
 
 export const DullahanRunnerAwsLambdaDefaultOptions = {
@@ -31,7 +32,8 @@ export const DullahanRunnerAwsLambdaDefaultOptions = {
     secretAccessKey: DULLAHAN_RUNNER_AWS_LAMBDA_AWS_SECRET_ACCESS_KEY || AWS_SECRET_ACCESS_KEY,
     slaveFunctionName: DULLAHAN_RUNNER_AWS_LAMBDA_AWS_LAMBDA_FUNCTION_NAME || AWS_LAMBDA_FUNCTION_NAME,
     slaveQualifier: DULLAHAN_RUNNER_AWS_LAMBDA_AWS_LAMBDA_FUNCTION_VERSION || AWS_LAMBDA_FUNCTION_VERSION,
-    slaveOptions: {}
+    slaveOptions: {},
+    useAccessKeys: true,
 };
 
 export type DullahanRunnerAwsLambdaOptions =


### PR DESCRIPTION
This updates the testdata to not be a string, but an object that has a success and failures property. This was implemented incorrectly.

This adds the useAccessKeys property, so we can call lambda functions from within a lambda function