### PR TITLE
chore: allow passing executablePath to puppeteer

### DIFF
--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
@@ -750,20 +750,23 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
         sessionId: string | null
     }> {
         const {options} = this;
-        const {headless, browserName, emulateDevice, userAgent} = options;
+        const {headless, browserName, emulateDevice, executablePath, userAgent} = options;
 
         if (this.browser) {
             throw new AdapterError(DullahanErrorMessage.ACTIVE_BROWSER);
         }
 
-        const browser = await Puppeteer.launch({
+        const launchOptions: Puppeteer.LaunchOptions = {
+            defaultViewport: null,
+            executablePath,
             headless,
             handleSIGINT: false,
-            defaultViewport: null,
             // @ts-ignore
             product: browserName,
             args: ['--no-sandbox']
-        });
+        };
+
+        const browser = await Puppeteer.launch(launchOptions);
         const pages = await browser.pages();
         const page = pages[pages.length - 1];
 

--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteerOptions.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteerOptions.ts
@@ -3,6 +3,7 @@ import {DullahanAdapterUserOptions, DullahanAdapterDefaultOptions} from '@k2g/du
 export type DullahanAdapterPuppeteerUserOptions = Partial<DullahanAdapterUserOptions & {
     browserName?: 'chrome' | 'firefox';
     emulateDevice?: string;
+    executablePath?: string;
     userAgent?: string;
  }>;
 


### PR DESCRIPTION
This allows using a custom binary as a browser.