### PR TITLE
chore: add options to puppeteer adapter

### DIFF
--- a/__snapshots__/env_nodejs/exports.ts.snap
+++ b/__snapshots__/env_nodejs/exports.ts.snap
@@ -118,12 +118,12 @@ exports[`@k2g/dullahan-adapter-playwright default should remain the same 1`] = `
 
 exports[`@k2g/dullahan-adapter-puppeteer DullahanAdapterPuppeteerDefaultOptions should remain the same 1`] = `
 Object {
-  "args": [],
+  "args": Array [],
   "browserName": "chrome",
   "debug": true,
   "devTools": false,
   "headless": false,
-  "rawOptions": {},
+  "rawOptions": Object {},
   "slowMotion": 0,
 }
 `;

--- a/__snapshots__/env_nodejs/exports.ts.snap
+++ b/__snapshots__/env_nodejs/exports.ts.snap
@@ -118,9 +118,12 @@ exports[`@k2g/dullahan-adapter-playwright default should remain the same 1`] = `
 
 exports[`@k2g/dullahan-adapter-puppeteer DullahanAdapterPuppeteerDefaultOptions should remain the same 1`] = `
 Object {
+  "args": [],
   "browserName": "chrome",
   "debug": true,
+  "devTools": false,
   "headless": false,
+  "rawOptions": {},
   "slowMotion": 0,
 }
 `;

--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
@@ -750,20 +750,20 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
         sessionId: string | null
     }> {
         const {options} = this;
-        const {headless, browserName, emulateDevice, executablePath, userAgent} = options;
+        const {args, devtools, headless, browserName, emulateDevice, executablePath, rawOptions, userAgent} = options;
 
         if (this.browser) {
             throw new AdapterError(DullahanErrorMessage.ACTIVE_BROWSER);
         }
 
-        const launchOptions: Puppeteer.LaunchOptions = {
+        const launchOptions = {
             defaultViewport: null,
+            devtools,
             executablePath,
             headless,
-            handleSIGINT: false,
-            // @ts-ignore
             product: browserName,
-            args: ['--no-sandbox']
+            ...rawOptions,
+            args
         };
 
         const browser = await Puppeteer.launch(launchOptions);

--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteerOptions.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteerOptions.ts
@@ -1,13 +1,19 @@
 import {DullahanAdapterUserOptions, DullahanAdapterDefaultOptions} from '@k2g/dullahan';
 
 export type DullahanAdapterPuppeteerUserOptions = Partial<DullahanAdapterUserOptions & {
+    args?: string[];
     browserName?: 'chrome' | 'firefox';
+    devtools?: boolean;
     emulateDevice?: string;
     executablePath?: string;
+    rawOptions: Record<string, unknown>;
     userAgent?: string;
  }>;
 
 export const DullahanAdapterPuppeteerDefaultOptions = {
     ...DullahanAdapterDefaultOptions,
-    browserName: 'chrome'
+    args: [],
+    browserName: 'chrome',
+    devTools: false,
+    rawOptions: {}
 };


### PR DESCRIPTION
This adds several missing options to the puppeteer adapter, so it can run in a Lambda environment