### PR TITLE
chore: create separate interactiveonly findOption

### DIFF
--- a/__tests__/env_browser/adapter/scrollToElement.ts
+++ b/__tests__/env_browser/adapter/scrollToElement.ts
@@ -48,9 +48,9 @@ describe('adapter.scrollToElement', () => {
             timeout: 2000
         });
 
-        const before = await adapter.isElementVisible(target);
+        const before = await adapter.isElementInteractable(target);
         await adapter.scrollToElement(target);
-        const after = await adapter.isElementVisible(target);
+        const after = await adapter.isElementInteractable(target);
 
         expect(before).toBe(false);
         expect(after).toBe(true);

--- a/packages/dullahan-adapter-playwright/src/DullahanAdapterPlaywright.ts
+++ b/packages/dullahan-adapter-playwright/src/DullahanAdapterPlaywright.ts
@@ -710,6 +710,29 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
         return element !== null;
     }
 
+    public async isElementInteractable(selector: string): Promise<boolean> {
+        const {page} = this;
+
+        if (!page) {
+            throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
+        }
+
+        const findOptions: FindElementOptions = {
+            selector,
+            visibleOnly: true,
+            onScreenOnly: true,
+            interactiveOnly: true,
+            timeout: 200,
+            promise: true,
+            expectNoMatches: false
+        };
+
+        const elementHandle = await page.evaluateHandle(findElement, findOptions);
+        const element = elementHandle.asElement();
+
+        return element !== null;
+    }
+
     public async moveMouseTo(x: number, y: number): Promise<void> {
         const {page} = this;
 

--- a/packages/dullahan-adapter-playwright/src/DullahanAdapterPlaywright.ts
+++ b/packages/dullahan-adapter-playwright/src/DullahanAdapterPlaywright.ts
@@ -66,6 +66,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -92,6 +93,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -120,6 +122,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -148,6 +151,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -176,6 +180,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -250,6 +255,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -286,6 +292,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -312,6 +319,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -338,6 +346,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -365,6 +374,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout,
             promise: true,
             expectNoMatches: true
@@ -398,6 +408,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: false,
             timeout,
             promise: true,
             expectNoMatches: true
@@ -470,6 +481,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -501,6 +513,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -557,6 +570,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -583,6 +597,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -617,6 +632,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -659,6 +675,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -681,6 +698,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -713,6 +731,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -741,6 +760,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -818,6 +838,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -885,6 +906,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout,
             promise: true,
             expectNoMatches: false
@@ -920,6 +942,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: false,
             timeout,
             promise: true,
             expectNoMatches: false

--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
@@ -698,6 +698,29 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
         return element !== null;
     }
 
+    public async isElementInteractable(selector: string): Promise<boolean> {
+        const {page} = this;
+
+        if (!page) {
+            throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
+        }
+
+        const findOptions: FindElementOptions = {
+            selector,
+            visibleOnly: true,
+            onScreenOnly: true,
+            interactiveOnly: true,
+            timeout: 200,
+            promise: true,
+            expectNoMatches: false
+        };
+
+        const elementHandle = await page.evaluateHandle(findElement, findOptions);
+        const element = elementHandle.asElement();
+
+        return element !== null;
+    }
+
     public async moveMouseTo(x: number, y: number): Promise<void> {
         const {page} = this;
 

--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
@@ -67,6 +67,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -93,6 +94,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -121,6 +123,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -149,6 +152,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -177,6 +181,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -248,6 +253,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -284,6 +290,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -310,6 +317,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -336,6 +344,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -363,6 +372,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout,
             promise: true,
             expectNoMatches: true
@@ -396,6 +406,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: false,
             timeout,
             promise: true,
             expectNoMatches: true
@@ -468,6 +479,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -495,6 +507,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -545,6 +558,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -571,6 +585,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -605,6 +620,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -647,6 +663,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -669,6 +686,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -701,6 +719,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -729,6 +748,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -822,6 +842,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false
@@ -888,6 +909,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout,
             promise: true,
             expectNoMatches: false
@@ -923,6 +945,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: false,
             timeout,
             promise: true,
             expectNoMatches: false

--- a/packages/dullahan-adapter-selenium-3/src/DullahanAdapterSelenium3.ts
+++ b/packages/dullahan-adapter-selenium-3/src/DullahanAdapterSelenium3.ts
@@ -874,6 +874,36 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
         }
     }
 
+    public async isElementInteractable(selector: string): Promise<boolean> {
+        const {driver, supportsPromises} = this;
+
+        if (!driver) {
+            throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
+        }
+
+        const findOptions: FindElementOptions = {
+            selector,
+            visibleOnly: true,
+            onScreenOnly: true,
+            interactiveOnly: true,
+            timeout: 200,
+            promise: supportsPromises,
+            expectNoMatches: false
+        };
+
+        try {
+            const element = await driver.executeScript<WebElement | null>(findElement, findOptions);
+
+            return !!element;
+        } catch (error) {
+            if (/unloaded|destroyed/ui.test(error.message)) {
+                return this.isElementInteractable(selector);
+            }
+
+            throw error;
+        }
+    }
+
     public async moveMouseTo(x: number, y: number): Promise<void> {
         const {driver, supportsPromises} = this;
 

--- a/packages/dullahan-adapter-selenium-3/src/DullahanAdapterSelenium3.ts
+++ b/packages/dullahan-adapter-selenium-3/src/DullahanAdapterSelenium3.ts
@@ -92,6 +92,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -117,6 +118,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -160,6 +162,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -205,6 +208,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -248,6 +252,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -344,6 +349,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -394,6 +400,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -419,6 +426,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -459,6 +467,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -485,6 +494,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout,
             promise: supportsPromises,
             expectNoMatches: true
@@ -519,6 +529,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: false,
             timeout,
             promise: supportsPromises,
             expectNoMatches: true
@@ -579,6 +590,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector: 'body',
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -607,6 +619,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -650,6 +663,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -717,6 +731,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -742,6 +757,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -767,6 +783,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -808,6 +825,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -837,6 +855,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -866,6 +885,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector: 'body',
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -894,6 +914,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -922,6 +943,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -1009,6 +1031,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector: 'body',
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -1042,6 +1065,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector: 'body',
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -1070,6 +1094,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -1133,6 +1158,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout,
             promise: supportsPromises,
             expectNoMatches: false
@@ -1169,6 +1195,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: false,
             timeout,
             promise: supportsPromises,
             expectNoMatches: false

--- a/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
+++ b/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
@@ -852,6 +852,36 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
         }
     }
 
+    public async isElementInteractable(selector: string): Promise<boolean> {
+        const {driver, supportsPromises} = this;
+
+        if (!driver) {
+            throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
+        }
+
+        const findOptions: FindElementOptions = {
+            selector,
+            visibleOnly: true,
+            onScreenOnly: true,
+            interactiveOnly: false,
+            timeout: 200,
+            promise: supportsPromises,
+            expectNoMatches: false
+        };
+
+        try {
+            const element = await driver.executeScript<WebElement | null>(findElement, findOptions);
+
+            return !!element;
+        } catch (error) {
+            if (/unloaded|destroyed/ui.test(error.message)) {
+                return this.isElementInteractable(selector);
+            }
+
+            throw error;
+        }
+    }
+
     public async moveMouseTo(x: number, y: number): Promise<void> {
         const {driver, viewportAdjustmentX, viewportAdjustmentY} = this;
 

--- a/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
+++ b/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
@@ -863,7 +863,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
-            interactiveOnly: false,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false

--- a/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
+++ b/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
@@ -98,6 +98,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -123,6 +124,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -170,6 +172,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -217,6 +220,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -264,6 +268,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -362,6 +367,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -412,6 +418,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -437,6 +444,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -477,6 +485,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -503,6 +512,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout,
             promise: supportsPromises,
             expectNoMatches: true
@@ -537,6 +547,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: false,
             timeout,
             promise: supportsPromises,
             expectNoMatches: true
@@ -609,6 +620,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -644,6 +656,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -696,6 +709,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -721,6 +735,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -746,6 +761,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -787,6 +803,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -816,6 +833,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -860,6 +878,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -895,6 +914,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: true,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -1004,6 +1024,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout: 200,
             promise: supportsPromises,
             expectNoMatches: false
@@ -1067,6 +1088,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: false,
             onScreenOnly: false,
+            interactiveOnly: false,
             timeout,
             promise: supportsPromises,
             expectNoMatches: false
@@ -1103,6 +1125,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
+            interactiveOnly: false,
             timeout,
             promise: supportsPromises,
             expectNoMatches: false

--- a/packages/dullahan/src/adapter/DullahanAdapter.ts
+++ b/packages/dullahan/src/adapter/DullahanAdapter.ts
@@ -80,6 +80,8 @@ export abstract class DullahanAdapter<DullahanAdapterSubclassUserOptions extends
 
     public abstract async isElementVisible(selector: string): Promise<boolean>;
 
+    public abstract async isElementInteractable(selector: string): Promise<boolean>;
+
     public abstract async moveMouseTo(x: number, y: number): Promise<void>;
 
     public abstract async moveMouseToElement(selector: string, offsetX: number, offsetY: number): Promise<void>;

--- a/packages/dullahan/src/browser_helpers/findElement.ts
+++ b/packages/dullahan/src/browser_helpers/findElement.ts
@@ -17,6 +17,7 @@ export type FindElementOptions = {
     selector: string;
     visibleOnly: boolean;
     onScreenOnly: boolean;
+    interactiveOnly: boolean;
     expectNoMatches: boolean;
     timeout: number;
     promise: boolean;
@@ -43,6 +44,7 @@ export function findElement(this: void, options: FindElementOptions): Element | 
     var selector = options.selector;
     var visibleOnly = options.visibleOnly;
     var onScreenOnly = options.onScreenOnly;
+    var interactiveOnly = options.interactiveOnly;
     var expectNoMatches = options.expectNoMatches;
     var timeout = options.timeout;
     var promise = options.promise !== false && typeof Promise !== 'undefined' && timeout > 0;
@@ -196,8 +198,13 @@ export function findElement(this: void, options: FindElementOptions): Element | 
                 return false;
             }
 
-            if (visibleOnly && (!hasDimensions(width, height) || !hasValidStyles(element) || !isInteractable(element, top, left, width, height))) {
+            if (visibleOnly && (!hasDimensions(width, height) || !hasValidStyles(element))) {
                 console.log('findElement', 'visibleOnly', selector, element);
+                return false;
+            }
+
+            if (interactiveOnly && !isInteractable(element, top, left, width, height)) {
+                console.log('findElement', 'interactiveOnly', selector, element);
                 return false;
             }
 


### PR DESCRIPTION
This implements an interactiveOnly option when finding elements. It prevents the visibility check from failing, since an element does not need to be interactive to be visible.