### PR TITLE
chore: implement waitforelementinteractive command

### DIFF
--- a/packages/dullahan-adapter-playwright/src/DullahanAdapterPlaywright.ts
+++ b/packages/dullahan-adapter-playwright/src/DullahanAdapterPlaywright.ts
@@ -986,4 +986,40 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             throw error;
         }
     }
+
+    public async waitForElementInteractive(selector: string, options: {
+        timeout: number;
+    }): Promise<void> {
+        const {page} = this;
+        const {timeout} = options;
+
+        if (!page) {
+            throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
+        }
+
+        const findOptions: FindElementOptions = {
+            selector,
+            visibleOnly: true,
+            onScreenOnly: true,
+            interactiveOnly: false,
+            timeout,
+            promise: true,
+            expectNoMatches: false
+        };
+
+        try {
+            const elementHandle = await page.evaluateHandle(findElement, findOptions);
+            const element = elementHandle.asElement();
+
+            if (!element) {
+                throw new AdapterError(DullahanErrorMessage.findElementResult(findOptions));
+            }
+        } catch (error) {
+            if (error.name === 'TimeoutError') {
+                throw new AdapterError(DullahanErrorMessage.findElementResult(findOptions));
+            }
+
+            throw error;
+        }
+    }
 }

--- a/packages/dullahan-adapter-playwright/src/DullahanAdapterPlaywright.ts
+++ b/packages/dullahan-adapter-playwright/src/DullahanAdapterPlaywright.ts
@@ -1001,7 +1001,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             selector,
             visibleOnly: true,
             onScreenOnly: true,
-            interactiveOnly: false,
+            interactiveOnly: true,
             timeout,
             promise: true,
             expectNoMatches: false

--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
@@ -1022,7 +1022,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
-            interactiveOnly: false,
+            interactiveOnly: true,
             timeout,
             promise: true,
             expectNoMatches: false

--- a/packages/dullahan-adapter-selenium-3/src/DullahanAdapterSelenium3.ts
+++ b/packages/dullahan-adapter-selenium-3/src/DullahanAdapterSelenium3.ts
@@ -1262,7 +1262,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
-            interactiveOnly: false,
+            interactiveOnly: true,
             timeout,
             promise: supportsPromises,
             expectNoMatches: false

--- a/packages/dullahan-adapter-selenium-3/src/DullahanAdapterSelenium3.ts
+++ b/packages/dullahan-adapter-selenium-3/src/DullahanAdapterSelenium3.ts
@@ -1247,4 +1247,41 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
             throw error;
         }
     }
+
+    public async waitForElementInteractive(selector: string, options: {
+        timeout: number;
+    }): Promise<void> {
+        const {driver, supportsPromises} = this;
+        const {timeout} = options;
+
+        if (!driver) {
+            throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
+        }
+
+        const findOptions: FindElementOptions = {
+            selector,
+            visibleOnly: true,
+            onScreenOnly: true,
+            interactiveOnly: false,
+            timeout,
+            promise: supportsPromises,
+            expectNoMatches: false
+        };
+
+        try {
+            const element = await driver.wait(() => driver.executeScript<WebElement | null>(findElement, findOptions), timeout || 1);
+
+            if (!element) {
+                throw new AdapterError(DullahanErrorMessage.findElementResult(findOptions));
+            }
+        } catch (error) {
+            if (error.name === 'TimeoutError') {
+                throw new AdapterError(DullahanErrorMessage.findElementResult(findOptions));
+            } else if (/unloaded|destroyed/ui.test(error.message)) {
+                return this.waitForElementInteractive(selector, options);
+            }
+
+            throw error;
+        }
+    }
 }

--- a/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
+++ b/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
@@ -1171,7 +1171,44 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             if (error.name === 'TimeoutError') {
                 throw new AdapterError(DullahanErrorMessage.findElementResult(findOptions));
             } else if (/unloaded|destroyed/ui.test(error.message)) {
-                return this.waitForElementPresent(selector, options);
+                return this.waitForElementVisible(selector, options);
+            }
+
+            throw error;
+        }
+    }
+
+    public async waitForElementInteractive(selector: string, options: {
+        timeout: number;
+    }): Promise<void> {
+        const {driver, supportsPromises} = this;
+        const {timeout} = options;
+
+        if (!driver) {
+            throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
+        }
+
+        const findOptions: FindElementOptions = {
+            selector,
+            visibleOnly: true,
+            onScreenOnly: true,
+            interactiveOnly: true,
+            timeout,
+            promise: supportsPromises,
+            expectNoMatches: false
+        };
+
+        try {
+            const element = await driver.wait(() => driver.executeScript<WebElement | null>(findElement, findOptions), timeout || 1);
+
+            if (!element) {
+                throw new AdapterError(DullahanErrorMessage.findElementResult(findOptions));
+            }
+        } catch (error) {
+            if (error.name === 'TimeoutError') {
+                throw new AdapterError(DullahanErrorMessage.findElementResult(findOptions));
+            } else if (/unloaded|destroyed/ui.test(error.message)) {
+                return this.waitForElementInteractive(selector, options);
             }
 
             throw error;

--- a/packages/dullahan/src/adapter/DullahanAdapter.ts
+++ b/packages/dullahan/src/adapter/DullahanAdapter.ts
@@ -148,6 +148,10 @@ export abstract class DullahanAdapter<DullahanAdapterSubclassUserOptions extends
         timeout: number;
     }): Promise<void>;
 
+    public abstract async waitForElementInteractive(selector: string, options: {
+        timeout: number;
+    }): Promise<void>;
+
     public abstract async waitForNavigation(trigger: () => (Promise<void> | void), options: {
         timeout: number;
         readyState: DullahanReadyState;

--- a/packages/dullahan/src/browser_helpers/setElementProperty.ts
+++ b/packages/dullahan/src/browser_helpers/setElementProperty.ts
@@ -14,12 +14,11 @@ export function setElementProperty(this: void, optionsOrElement: SetElementPrope
     element[propertyName] = propertyValue;
 
     if (propertyName === 'value') {
-        var inputEvent = document.createEvent('Event');
-        inputEvent.initEvent('input', true);
-        element.dispatchEvent(inputEvent);
-
-        var changeEvent = document.createEvent('Event');
-        changeEvent.initEvent('change', true);
-        element.dispatchEvent(changeEvent);
+        element.dispatchEvent(new Event('input', {
+            bubbles: true
+        }));
+        element.dispatchEvent(new Event('change', {
+            bubbles: true
+        }));
     }
 }


### PR DESCRIPTION
This implements the waitForElementInteractive command.

This fixes an issue where using a Select element does not trigger Events in the DOM. 