### PR TITLE
chore: improve markdown and do not replace in base64

### DIFF
--- a/packages/dullahan-plugin-aws-s3/src/DullahanPluginAwsS3.ts
+++ b/packages/dullahan-plugin-aws-s3/src/DullahanPluginAwsS3.ts
@@ -47,7 +47,7 @@ export default class DullahanPluginAwsS3 extends DullahanPlugin<
         }
     }
 
-    private getSecretRegex(secret: string | RegExp) {
+    private getRegexForSecret(secret: string | RegExp) {
         if (secret instanceof RegExp)    {
             return secret;
         }
@@ -66,7 +66,7 @@ export default class DullahanPluginAwsS3 extends DullahanPlugin<
         const url = new URL(`https://${bucketName}.s3.${region}.amazonaws.com/${Key}`);
 
         let safeData = data;
-        [...new Set([
+        encoding !== 'base64' && [...new Set([
             ...secrets,
             accessKeyId,
             secretAccessKey,
@@ -75,7 +75,7 @@ export default class DullahanPluginAwsS3 extends DullahanPlugin<
                 .map(([, value]) => value)
         ])].forEach((secret) => {
             if (secret) {
-                const searchValue = this.getSecretRegex(secret);
+                const searchValue = this.getRegexForSecret(secret);
                 safeData = safeData.replace(searchValue, '<secret>');
             }
         });

--- a/packages/dullahan-plugin-github/src/DullahanPluginGithub.ts
+++ b/packages/dullahan-plugin-github/src/DullahanPluginGithub.ts
@@ -154,7 +154,7 @@ export default class DullahanPluginGithub extends DullahanPlugin<DullahanPluginG
             repo: repositoryName,
             issue_number: pullRequestNumber
         });
-        const commentId = comments.find(({body}) => body.startsWith(identifier))?.id;
+        const commentId = comments.find(({body}) => body.includes(identifier))?.id;
 
         if (typeof commentId === 'number') {
             await octokit.issues.updateComment({

--- a/packages/dullahan-plugin-report-markdown/src/DullahanPluginReportMarkdown.ts
+++ b/packages/dullahan-plugin-report-markdown/src/DullahanPluginReportMarkdown.ts
@@ -58,10 +58,10 @@ export default class DullahanPluginReportMarkdown extends DullahanPlugin<Dullaha
         const successfulTests = tests.filter(isSuccessfulTest.bind(null, slowTestThreshold)).map(formatSuccessfulTest);
 
         const tables = [
-            failingTests.length && formatFailingTable(failingTests),
-            !hideUnstableTests && unstableTests.length && formatUnstableTable(unstableTests),
-            !hideSlowTests && slowTests.length && formatSlowTable(slowTests),
-            !hideSuccessfulTests && successfulTests.length && formatSuccessfulTable(successfulTests)
+            formatFailingTable(failingTests),
+            formatUnstableTable(unstableTests, hideUnstableTests),
+            formatSlowTable(slowTests, hideSlowTests),
+            formatSuccessfulTable(successfulTests, hideSuccessfulTests)
         ].filter((table) => !!table).join('\n');
 
         const data = [

--- a/packages/dullahan-plugin-report-markdown/src/helpers/formatter.ts
+++ b/packages/dullahan-plugin-report-markdown/src/helpers/formatter.ts
@@ -44,9 +44,13 @@ export const formatUnstableTest = (test: Test): string => {
     return `:heavy_multiplication_x: | ${testName} | ${Math.ceil((timeEnd - timeStart) / 1000)}s | ${calls.filter(({error}) => !!error).length}`;
 };
 
-export const formatUnstableTable = (rows: string[]) => {
+export const formatUnstableTable = (rows: string[], headerOnly: boolean) => {
+    const header = `## ${rows.length} Unstable tests`;
+    if (headerOnly) {
+        return [header];
+    }
     return [
-        `## ${rows.length} Unstable tests`,
+        header,
         'Result | Name | Time |  Error Count',
         ':---: | :--- | :---: | :---:',
         ...rows,
@@ -66,9 +70,13 @@ export const formatSlowTest = (test: Test) => {
     return fixLinebreaks(`:clock4: | ${testName} | ${Math.ceil((timeEnd - timeStart) / 1000)}s`);
 };
 
-export const formatSlowTable = (rows: string[]) => {
+export const formatSlowTable = (rows: string[], headerOnly) => {
+    const header = `## ${rows.length} Slow tests`;
+    if (headerOnly) {
+        return [header];
+    }
     return [
-        `## ${rows.length} Slow tests`,
+        header,
         `Result | Name | Time`,
         ':---: | :--- | :---:',
         ...rows,
@@ -88,9 +96,13 @@ export const formatSuccessfulTest = (test: Test) => {
     return fixLinebreaks(`:heavy_check_mark: | ${testName} | ${Math.ceil((timeEnd - timeStart) / 1000)}s`);
 };
 
-export const formatSuccessfulTable = (rows: string[]) => {
+export const formatSuccessfulTable = (rows: string[], headerOnly: boolean) => {
+    const header = `## ${rows.length} Successful tests`;
+    if (headerOnly) {
+        return [header];
+    }
     return [
-        `## ${rows.length} Successful tests`,
+        header,
         `Result | Name | Time`,
         ':---: | :--- | :---:',
         ...rows,

--- a/packages/dullahan-plugin-report-markdown/src/helpers/formatter.ts
+++ b/packages/dullahan-plugin-report-markdown/src/helpers/formatter.ts
@@ -23,6 +23,10 @@ export const formatFailingTest = (test: FailingTest): string => {
 };
 
 export const formatFailingTable = (rows: string[]) => {
+    const header = `## ${rows.length} Unstable tests`;
+    if (rows.length === 0) {
+        return [header];
+    }
     return [
         `## ${rows.length} Failing tests`,
         'Result | Name | Error |  Message',
@@ -46,7 +50,7 @@ export const formatUnstableTest = (test: Test): string => {
 
 export const formatUnstableTable = (rows: string[], headerOnly: boolean) => {
     const header = `## ${rows.length} Unstable tests`;
-    if (headerOnly) {
+    if (headerOnly || rows.length === 0) {
         return [header];
     }
     return [
@@ -72,7 +76,7 @@ export const formatSlowTest = (test: Test) => {
 
 export const formatSlowTable = (rows: string[], headerOnly) => {
     const header = `## ${rows.length} Slow tests`;
-    if (headerOnly) {
+    if (headerOnly || rows.length === 0) {
         return [header];
     }
     return [
@@ -98,7 +102,7 @@ export const formatSuccessfulTest = (test: Test) => {
 
 export const formatSuccessfulTable = (rows: string[], headerOnly: boolean) => {
     const header = `## ${rows.length} Successful tests`;
-    if (headerOnly) {
+    if (headerOnly || rows.length === 0) {
         return [header];
     }
     return [


### PR DESCRIPTION
- Hide only the body of the table of successful/slow/unstable tests and show a line even if there are 0 of these tests.
- Do not replace possible secrets inside a base64 (this triggers a promise rejection)