### PR TITLE
chore: do not check for interactive when clicking

### DIFF
--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
@@ -515,7 +515,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             selector,
             visibleOnly: true,
             onScreenOnly: true,
-            interactiveOnly: true,
+            interactiveOnly: false,
             timeout: 200,
             promise: true,
             expectNoMatches: false

--- a/packages/dullahan-plugin-github/src/DullahanPluginGithub.ts
+++ b/packages/dullahan-plugin-github/src/DullahanPluginGithub.ts
@@ -55,7 +55,7 @@ export default class DullahanPluginGithub extends DullahanPlugin<DullahanPluginG
             this.testIds.push(dtec.testId);
         }
 
-        if (enableStatusChecks && lastStatusCheck + 60000 > Date.now()) {
+        if (enableStatusChecks && lastStatusCheck + 15000 > Date.now()) {
             await this.setStatus();
         }
 


### PR DESCRIPTION
This makes sure clicks are performed when the element is visible.
This also lowers the time before updating the github status.