### PR TITLE
chore: add http options to the lambda runner

### DIFF
--- a/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambdaOptions.ts
+++ b/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambdaOptions.ts
@@ -1,4 +1,5 @@
 import {DullahanRunnerDefaultOptions, DullahanRunnerUserOptions} from '@k2g/dullahan';
+import { HTTPOptions } from 'aws-sdk';
 
 const {
     DULLAHAN_RUNNER_AWS_LAMBDA_AWS_LAMBDA_FUNCTION_NAME, AWS_LAMBDA_FUNCTION_NAME,
@@ -9,11 +10,12 @@ const {
 } = process.env;
 
 export type DullahanRunnerAwsLambdaUserOptions = Partial<DullahanRunnerUserOptions & {
-    role: 'master' | 'slave';
-    region: string;
     accessKeyId: string;
-    secretAccessKey: string;
+    httpOptions?: HTTPOptions;
     maxConcurrency: number;
+    region: string;
+    role: 'master' | 'slave';
+    secretAccessKey: string;
     slaveFunctionName: string;
     slaveQualifier: string;
     slaveOptions: {


### PR DESCRIPTION
Allow passing custom http options to the lambda runner