### PR TITLE
chore: show test time in html report

### DIFF
--- a/packages/dullahan-plugin-report-html/template/partials/test.ejs
+++ b/packages/dullahan-plugin-report-html/template/partials/test.ejs
@@ -1,5 +1,5 @@
 <details data-test-id="<%= test.testId %>">
-    <summary><%= test.testName %></summary>
+    <summary><%= test.testName %> (<%= (test.timeEnd - test.timeStart) / 1000 %>s)</summary>
     <% test.calls.forEach(function(call, index) { %>
         <% if (call.functionScope === 'api') { %>
             <div class="<%= call.error ? 'step step--error' : 'step' %>">

--- a/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambda.ts
+++ b/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambda.ts
@@ -200,6 +200,7 @@ export default class DullahanRunnerAwsLambda extends DullahanRunner<DullahanRunn
 
             return !testEndCall?.error;
         } catch (e) {
+            console.info('Failed with Payload', Payload);
             console.error(e);
             return false;
         }


### PR DESCRIPTION
- Show the test time in the default html report template.

- Log the payload when the lambda runner fails on parsing it