### PR TITLE
chore: improve markdown report

### DIFF
--- a/__snapshots__/env_nodejs/exports.ts.snap
+++ b/__snapshots__/env_nodejs/exports.ts.snap
@@ -236,7 +236,7 @@ Object {
   "hideUnstableTests": false,
   "reportTitle": "Dullahan Report",
   "reportTitleUrl": "https://dullahan.io",
-  "slowTestThreshold": 30000,
+  "slowTestThreshold": 60000,
 }
 `;
 

--- a/packages/dullahan-plugin-report-markdown/src/DullahanPluginReportMarkdownOptions.ts
+++ b/packages/dullahan-plugin-report-markdown/src/DullahanPluginReportMarkdownOptions.ts
@@ -13,7 +13,7 @@ export const DullahanPluginReportMarkdownDefaultOptions = {
     ...DullahanPluginDefaultOptions,
     reportTitle: 'Dullahan Report',
     reportTitleUrl: 'https://dullahan.io',
-    slowTestThreshold: 30000,
+    slowTestThreshold: 60000,
     hideUnstableTests: false,
     hideSlowTests: false,
     hideSuccessfulTests: false

--- a/packages/dullahan/src/DullahanClient.ts
+++ b/packages/dullahan/src/DullahanClient.ts
@@ -170,7 +170,7 @@ export class DullahanClient {
         testEndCalls: DullahanTestEndCall[];
         functionEndCalls: DullahanFunctionEndCall[];
     }> {
-        const {plugins, runner, storedArtifactPromises, testStartCalls, testEndPromises, functionStartCalls, functionEndPromises} = this;
+        const {plugins, runner, testStartCalls, testEndPromises, functionStartCalls, functionEndPromises} = this;
 
         console.log('Stopping runner');
         await runner.stop();
@@ -189,7 +189,7 @@ export class DullahanClient {
             const artifacts = await plugin.getArtifacts(testEndCalls, functionEndCalls);
             artifacts.forEach((artifact) => this.submitArtifact(artifact));
         }));
-        const storedArtifacts = await Promise.all(storedArtifactPromises);
+        const storedArtifacts = await Promise.all(this.storedArtifactPromises);
         await Promise.all(plugins.map(async (plugin) => plugin.processResults(storedArtifacts, testEndCalls, functionEndCalls).catch(console.error)));
         console.log('Processing artifacts complete');
 


### PR DESCRIPTION
- Make sure the `StoredArtifacts` are evaluated after the promises are resolved.
- Set the `slowTestThreshold` in the markdown report to 60 seconds, just like in other plugins.