### PR TITLE
chore: Added better typings for executeScript method

### DIFF
--- a/packages/dullahan/src/api/DullahanApi.ts
+++ b/packages/dullahan/src/api/DullahanApi.ts
@@ -560,7 +560,7 @@ export class DullahanApi<
         await adapter.sendKeysToElement(selector, text);
     }
 
-    public async executeScript(script: string) {
-        return this.adapter.executeScript(script);
+    public async executeScript<T = any>(script: string): Promise<T> {
+        return this.adapter.executeScript<T>(script);
     }
 }


### PR DESCRIPTION
We are now able to set the return type of executeScript.

