### PR TITLE
fix: do not screenshot full page to decrease size

### DIFF
--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
@@ -955,7 +955,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
 
         const screenshot = await page.screenshot({
             type: 'png',
-            fullPage: true,
+            fullPage: false,
             encoding: 'base64'
         });
 


### PR DESCRIPTION
The Lambda runner was exceeding the maximum allowed payload size - this should fix it. In the future, we should make this configurable in the puppeteer options.