### PR TITLE
fix: use default timeout of 15000

### DIFF
--- a/packages/dullahan-adapter-selenium-3/src/DullahanAdapterSelenium3.ts
+++ b/packages/dullahan-adapter-selenium-3/src/DullahanAdapterSelenium3.ts
@@ -506,7 +506,7 @@ export default class DullahanAdapterSelenium3 extends DullahanAdapter<DullahanAd
         };
 
         try {
-            const element = await driver.wait(async () => driver.executeScript<WebElement | null>(findElement, findOptions), timeout || 1);
+            const element = await driver.wait(async () => driver.executeScript<WebElement | null>(findElement, findOptions), timeout || 15000);
 
             if (element) {
                 throw new AdapterError(DullahanErrorMessage.findElementResult(findOptions));


### PR DESCRIPTION
Change the timeout from `1` to `15000`, because it would always fail otherwise.