### PR TITLE
fix: only mention if the value is defined

### DIFF
--- a/packages/dullahan-plugin-slack/src/DullahanPluginSlack.ts
+++ b/packages/dullahan-plugin-slack/src/DullahanPluginSlack.ts
@@ -86,7 +86,7 @@ export default class DullahanPluginSlack extends DullahanPlugin<DullahanPluginSl
                 type: 'section',
                 text: {
                     type: 'mrkdwn',
-                    text: `${failingTests.length ? mention : ''} New results: ${failingTests.length} failing tests, ${unstableTests.length} unstable tests, ${slowTests.length} slow tests and ${successfulTests.length} successful tests`
+                    text: `${failingTests.length && mention ? mention : ''} New results: ${failingTests.length} failing tests, ${unstableTests.length} unstable tests, ${slowTests.length} slow tests and ${successfulTests.length} successful tests`
                 }
             }, {
                 type: 'divider'


### PR DESCRIPTION
As stated in PR title - this only prints the value of mention if it is defined.