### PR TITLE
feat: Selenium 4 can now use events instead of actions.

### DIFF
--- a/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4Options.ts
+++ b/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4Options.ts
@@ -15,6 +15,7 @@ export const DullahanAdapterSelenium4DefaultOptions = {
     ...DullahanAdapterDefaultOptions,
     browserName: 'chrome',
     maximizeWindow: true,
+    useActions: true,
     rawCapabilities: {}
 };
 


### PR DESCRIPTION
The selenium 4 adapter can now use events instead of actions for
browsers that don't support actions. A new option was added `useActions`
which default is set too true, set it too `false` to use events.

BREAKING CHANGE: 🧨 The selenium 4 adapter no longer automatically uses some events instead of
actions on edge, you need to manually set the `useActions` option too `false`.

