### PR TITLE
feat: Puppeteer can now use touch instead of click.

### DIFF
--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
@@ -497,7 +497,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
     }
 
     public async click(selector: string): Promise<void> {
-        const {page} = this;
+        const {page, options: {useTouch}} = this;
 
         if (!page) {
             throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
@@ -520,21 +520,29 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             throw new AdapterError(DullahanErrorMessage.findElementResult(findOptions));
         }
 
+        if (useTouch) {
+            return element.tap();
+        }
+
         await element.click();
     }
 
     public async clickAt(x: number, y: number): Promise<void> {
-        const {page} = this;
+        const {page, options: {useTouch}} = this;
 
         if (!page) {
             throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
+        }
+
+        if (useTouch) {
+            return page.touchscreen.tap(x, y);
         }
 
         await page.mouse.click(x, y);
     }
 
     public async clickAtElement(selector: string, offsetX: number, offsetY: number): Promise<void> {
-        const {page} = this;
+        const {page, options: {useTouch}} = this;
 
         if (!page) {
             throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
@@ -558,11 +566,18 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
         }
 
         const {x: elementX, y: elementY} = await page.evaluate(getBoundingClientRect, element);
-        await page.mouse.click(elementX + offsetX, elementY + offsetY);
+        const x = elementX + offsetX;
+        const y = elementY + offsetY;
+
+        if (useTouch) {
+            return page.touchscreen.tap(x, y);
+        }
+
+        await page.mouse.click(x, y);
     }
 
     public async clickAtElementCenter(selector: string, offsetCenterX: number, offsetCenterY: number): Promise<void> {
-        const {page} = this;
+        const {page, options: {useTouch}} = this;
 
         if (!page) {
             throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
@@ -586,7 +601,14 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
         }
 
         const {x: elementX, y: elementY, width, height} = await page.evaluate(getBoundingClientRect, element);
-        await page.mouse.click(elementX + offsetCenterX + width / 2, elementY + offsetCenterY + height / 2);
+        const x = elementX + offsetCenterX + width / 2;
+        const y = elementY + offsetCenterY + height / 2;
+
+        if (useTouch) {
+            return page.touchscreen.tap(x, y);
+        }
+
+        await page.mouse.click(x, y);
     }
 
     public async closeBrowser(): Promise<void> {

--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteerOptions.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteerOptions.ts
@@ -5,6 +5,7 @@ export type DullahanAdapterPuppeteerUserOptions = Partial<DullahanAdapterUserOpt
     browserName?: 'chrome' | 'firefox';
     devtools?: boolean;
     emulateDevice?: string;
+    useTouch?: boolean;
     executablePath?: string;
     rawOptions: Record<string, unknown>;
     userAgent?: string;
@@ -15,5 +16,6 @@ export const DullahanAdapterPuppeteerDefaultOptions = {
     args: [],
     browserName: 'chrome',
     devTools: false,
+    useTouch: false,
     rawOptions: {}
 };


### PR DESCRIPTION
Puppeteer can now be configured to use touch instead of clicks, by
setting the `useTouch` option.

