### PR TITLE
feat: use earlytermination flag to set failure state

### DIFF
--- a/packages/dullahan/src/DullahanClient.ts
+++ b/packages/dullahan/src/DullahanClient.ts
@@ -166,12 +166,12 @@ export class DullahanClient {
         await runner.start();
     }
 
-    public async stop(): Promise<{
+    public async stop(earlyTermination = false): Promise<{
         storedArtifacts: StoredArtifact[];
         testEndCalls: DullahanTestEndCall[];
         functionEndCalls: DullahanFunctionEndCall[];
     }> {
-        const {plugins, runner, testStartCalls, testEndPromises, functionStartCalls, functionEndPromises} = this;
+        const {plugins, runner, testEndPromises, functionEndPromises} = this;
 
         console.log('Stopping runner');
         await runner.stop();
@@ -191,7 +191,7 @@ export class DullahanClient {
             artifacts.forEach((artifact) => this.submitArtifact(artifact));
         }));
         const storedArtifacts = await Promise.all(this.storedArtifactPromises);
-        await Promise.all(plugins.map(async (plugin) => plugin.processResults(storedArtifacts, testEndCalls, functionEndCalls).catch(console.error)));
+        await Promise.all(plugins.map(async (plugin) => plugin.processResults(storedArtifacts, testEndCalls, functionEndCalls, earlyTermination).catch(console.error)));
         console.log('Processing artifacts complete');
 
         return {

--- a/packages/dullahan/src/DullahanPlugin.ts
+++ b/packages/dullahan/src/DullahanPlugin.ts
@@ -71,7 +71,7 @@ export abstract class DullahanPlugin<
         return null;
     }
 
-    public async processResults(artifacts: StoredArtifact[], dtecs: DullahanTestEndCall[], dfecs: DullahanFunctionEndCall[]): Promise<void> {
+    public async processResults(artifacts: StoredArtifact[], dtecs: DullahanTestEndCall[], dfecs: DullahanFunctionEndCall[], earlyTermination: boolean): Promise<void> {
         // Nothing
     }
 }


### PR DESCRIPTION
Use a flag in `dullahan.stop()` so we can terminate early and set the github status to a failure. We can use this in the future to improve other plugins as well.