### PR TITLE
chore: show dullahan configuration in the html report

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,7 +10,7 @@ jobs:
     test_nodejs:
         strategy:
             matrix:
-                node: [10, 12, 14]
+                node: [12, 14]
         name: ${{ matrix.node }}
         runs-on: ubuntu-latest
         steps:

--- a/packages/dullahan-plugin-report-html/src/DullahanPluginReportHtml.ts
+++ b/packages/dullahan-plugin-report-html/src/DullahanPluginReportHtml.ts
@@ -86,7 +86,10 @@ export default class DullahanPluginReportHtml extends DullahanPlugin<DullahanPlu
                 unstableTests,
                 slowTests,
                 successfulTests,
-                ...options
+                ...options,
+                config: {
+                    ...this.client.config
+                }
             }, {
                 filename,
                 rmWhitespace: true

--- a/packages/dullahan-plugin-report-html/template/partials/config.ejs
+++ b/packages/dullahan-plugin-report-html/template/partials/config.ejs
@@ -1,0 +1,14 @@
+<% if (config) { %>
+    <details>
+        <summary><%= `${title}` %> config</summary>
+        <section>
+            <div>Package: <strong><%= `${config[0]}` %></strong></div>
+            <div>Options:</div>
+            <ul>
+                <% Object.entries(config[1]).forEach(function(option) { %>
+                    <li><%= `${option[0]}` %>: <%= `${option[1]}` %></li>
+                <% }) %>
+            </ul>
+        </section>
+    </details>
+<% } %>

--- a/packages/dullahan-plugin-report-html/template/partials/styles.ejs
+++ b/packages/dullahan-plugin-report-html/template/partials/styles.ejs
@@ -162,6 +162,19 @@
         border: 1px solid var(--color-grey);
     }
 
+    section.configuration {
+        display: flex;
+    }
+
+    section.configuration > span {
+        flex: 1 0 33%;
+        background-color: var(--color-grey);
+    }
+
+    section.configuration > span > h2 {
+        margin-top: 0;
+    }
+
     @media all and (max-width: 768px) {
         h1 {
             font-size: 2rem;
@@ -173,8 +186,11 @@
         }
 
         section.configuration {
-            grid-row-gap: 1em;
-            grid-template-areas: "title title title" "system system system" "filter filter filter" "plugins plugins plugins";
+            flex-direction: column;
+        }
+
+        section.configuration > span {
+            flex: 1 0 100%;
         }
     }
 </style>

--- a/packages/dullahan-plugin-report-html/template/report.ejs
+++ b/packages/dullahan-plugin-report-html/template/report.ejs
@@ -8,6 +8,19 @@
 <body>
 <section class="header">
     <h1><span class="header--icon"></span><span><%= reportTitle %></span></h1>
+    <% if (config) { %>
+        <section class="configuration">
+            <span>
+                <%- include('partials/config', {config: config.runner, title: 'Runner'}); %>
+            </span>
+            <span>
+                <%- include('partials/config', {config: config.api, title: 'Api'}); %>
+            </span>
+            <span>
+                <%- include('partials/config', {config: config.adapter, title: 'Adapter'}); %>
+            </span>
+        </section>
+    <% } %>
 </section>
 
 <% if (failingTests.length) { %>

--- a/packages/dullahan/src/DullahanClient.ts
+++ b/packages/dullahan/src/DullahanClient.ts
@@ -52,7 +52,7 @@ export class DullahanClient {
 
     private Adapter: AdapterConstructor;
 
-    private readonly config: DullahanConfig;
+    public readonly config: DullahanConfig;
 
     private readonly runner: DullahanRunner<never, never>;
 


### PR DESCRIPTION
Improve the html report by showing the used dullahan configuration. This will make debugging easier.