### PR TITLE
Fix autoscroll for click

### DIFF
--- a/packages/dullahan/src/api/DullahanApi.ts
+++ b/packages/dullahan/src/api/DullahanApi.ts
@@ -88,11 +88,11 @@ export class DullahanApi<
         const {adapter, options} = this;
         const {defaultTimeout, autoScroll} = options;
 
-        if (autoScroll && !(await adapter.isElementVisible(selector))) {
+        if (autoScroll && !(await adapter.isElementInteractable(selector))) {
             await this.scrollToElement(selector, timeout);
         }
 
-        await adapter.waitForElementVisible(selector, {
+        await adapter.waitForElementInteractive(selector, {
             timeout: timeout ?? defaultTimeout
         });
         await adapter.click(selector);


### PR DESCRIPTION
Use waitForElementInteractive instead of visible inside 'click()'. This will make sure if the given element is not clickable(e.g. interactive) it will autoscroll(when enabled).