### PR TITLE
chore: simplify dependency resolution

### DIFF
--- a/__snapshots__/env_nodejs/exports.ts.snap
+++ b/__snapshots__/env_nodejs/exports.ts.snap
@@ -83,7 +83,13 @@ exports[`@k2g/dullahan getElementProperties should remain the same 1`] = `[Funct
 
 exports[`@k2g/dullahan getElementStyles should remain the same 1`] = `[Function]`;
 
+exports[`@k2g/dullahan isAbsolutePath should remain the same 1`] = `[Function]`;
+
 exports[`@k2g/dullahan isDullahanConfig should remain the same 1`] = `[Function]`;
+
+exports[`@k2g/dullahan isModulePath should remain the same 1`] = `[Function]`;
+
+exports[`@k2g/dullahan isRelativePath should remain the same 1`] = `[Function]`;
 
 exports[`@k2g/dullahan isValidTest should remain the same 1`] = `[Function]`;
 

--- a/packages/dullahan/__tests__/dependencies.ts
+++ b/packages/dullahan/__tests__/dependencies.ts
@@ -1,0 +1,61 @@
+import {isAbsolutePath, isRelativePath, isModulePath} from '@k2g/dullahan';
+
+describe('isAbsolutePath', () => {
+
+    it('should identify unix-style absolute paths', () => {
+        expect(isAbsolutePath('/home/me/file.js')).toBe(true);
+    });
+
+    it('should identify windows-style absolute paths', () => {
+        expect(isAbsolutePath('C:\\Users\\Me\\file.js')).toBe(true);
+    });
+
+    it('should not yield false-positives for invalid, relative or module paths', () => {
+        expect(isAbsolutePath('')).toBe(false);
+        expect(isAbsolutePath('./file.js')).toBe(false);
+        expect(isAbsolutePath('../file.js')).toBe(false);
+        expect(isAbsolutePath('.\\file.js')).toBe(false);
+        expect(isAbsolutePath('..\\file.js')).toBe(false);
+        expect(isAbsolutePath('@k2g/dullahan')).toBe(false);
+        expect(isAbsolutePath('dullahan')).toBe(false);
+    });
+});
+
+describe('isRelativePath', () => {
+
+    it('should identify unix-style relative paths', () => {
+        expect(isRelativePath('./file.js')).toBe(true);
+        expect(isRelativePath('../file.js')).toBe(true);
+    });
+
+    it('should identify windows-style relative paths', () => {
+        expect(isRelativePath('.\\file.js')).toBe(true);
+        expect(isRelativePath('..\\file.js')).toBe(true);
+    });
+
+    it('should not yield false-positives for invalid, absolute or module paths', () => {
+        expect(isRelativePath('')).toBe(false);
+        expect(isRelativePath('/home/me/file.js')).toBe(false);
+        expect(isRelativePath('C:\\Users\\Me\\file.js')).toBe(false);
+        expect(isRelativePath('@k2g/dullahan')).toBe(false);
+        expect(isRelativePath('dullahan')).toBe(false);
+    });
+});
+
+describe('isModulePath', () => {
+
+    it('should identify module paths', () => {
+        expect(isModulePath('@k2g/dullahan')).toBe(true);
+        expect(isModulePath('dullahan')).toBe(true);
+    });
+
+    it('should not yield false-positives for invalid, absolute or module paths', () => {
+        expect(isModulePath('')).toBe(false);
+        expect(isModulePath('/home/me/file.js')).toBe(false);
+        expect(isModulePath('C:\\Users\\Me\\file.js')).toBe(false);
+        expect(isModulePath('./file.js')).toBe(false);
+        expect(isModulePath('../file.js')).toBe(false);
+        expect(isModulePath('.\\file.js')).toBe(false);
+        expect(isModulePath('..\\file.js')).toBe(false);
+    });
+});

--- a/packages/dullahan/src/nodejs_helpers/index.ts
+++ b/packages/dullahan/src/nodejs_helpers/index.ts
@@ -4,3 +4,4 @@ export * from './sleep';
 export * from './requireDependency';
 export * from './options';
 export * from './runModifiedTests';
+export * from './types';

--- a/packages/dullahan/src/nodejs_helpers/types.ts
+++ b/packages/dullahan/src/nodejs_helpers/types.ts
@@ -1,0 +1,49 @@
+export type AbsolutePath = string;
+export type RelativePath = string;
+export type ModulePath = string;
+export type DependencyPath = AbsolutePath | RelativePath | ModulePath;
+
+/**
+ * Checks the path to be an absolute path.
+ * Does not check for the existence of a file extension.
+ * Does not check if the file or directory actually exists.
+ *
+ * @example
+ * import '/home/me/file.js';
+ * import 'C:\Users\Me\file.js';
+ *
+ * @param path Any string that could be used in a require call.
+ */
+export const isAbsolutePath = (path: string): path is AbsolutePath => {
+  return /^(\/|[a-z]:)/i.test(path);
+};
+
+/**
+ * Checks the path to be a relative path.
+ * Does not check for the existence of a file extension.
+ * Does not check if the file or directory actually exists.
+ *
+ * @example
+ * import './file';
+ * import '../file';
+ *
+ * @param path Any string that could be used in a require call.
+ */
+export const isRelativePath = (path: string): path is RelativePath => {
+    return path.startsWith('.');
+};
+
+/**
+ * Checks the path to be a module path.
+ * Does not check for the existence of a file extension.
+ * Does not check if the file or directory actually exists.
+ *
+ * @example
+ * import 'jquery';
+ * import 'jquery/file';
+ *
+ * @param path Any string that could be used in a require call.
+ */
+export const isModulePath = (path: string): path is ModulePath => {
+    return !!path.length && !isRelativePath(path) && !isAbsolutePath(path);
+};


### PR DESCRIPTION
Dependency resolution contained a lot of guessing during runtime;
this change reduces the amount of guessing.

BREAKING CHANGE: Config files that have relative paths like
'MyDullahanApi.ts' must be updated to './MyDullahanApi.ts' to be
resolved relative to the current working directory.

