### PR TITLE
feat: accept a number of failures for the failFast option

### DIFF
--- a/packages/dullahan/src/runner/DullahanRunnerOptions.ts
+++ b/packages/dullahan/src/runner/DullahanRunnerOptions.ts
@@ -1,7 +1,7 @@
 import {DullahanTest} from '../DullahanTest';
 
 export type DullahanRunnerUserOptions = Partial<{
-    failFast: boolean;
+    failFast: boolean | number;
     minSuccesses: number;
     maxAttempts: number;
     rootDirectories: string[];


### PR DESCRIPTION
This also allows us to remove a Kaartje2go-specific configuration
where the runner would always quit after 20 tests have failed,
regardless of the provided options