### PR TITLE
feat: add rateLimitConcurrency option

### DIFF
--- a/__snapshots__/env_nodejs/exports.ts.snap
+++ b/__snapshots__/env_nodejs/exports.ts.snap
@@ -276,6 +276,7 @@ Object {
   "maxAttempts": 1,
   "maxConcurrency": 900,
   "minSuccesses": 1,
+  "rateLimitConcurrency": Infinity,
   "region": undefined,
   "role": "master",
   "rootDirectories": Array [],

--- a/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambdaOptions.ts
+++ b/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambdaOptions.ts
@@ -13,6 +13,7 @@ export type DullahanRunnerAwsLambdaUserOptions = Partial<DullahanRunnerUserOptio
     accessKeyId: string;
     httpOptions?: HTTPOptions;
     maxConcurrency: number;
+    rateLimitConcurrency: number;
     region: string;
     role: 'master' | 'slave';
     secretAccessKey: string;
@@ -28,6 +29,7 @@ export type DullahanRunnerAwsLambdaUserOptions = Partial<DullahanRunnerUserOptio
 export const DullahanRunnerAwsLambdaDefaultOptions = {
     ...DullahanRunnerDefaultOptions,
     maxConcurrency: 900,
+    rateLimitConcurrency: Infinity,
     role: 'master',
     region: DULLAHAN_RUNNER_AWS_LAMBDA_AWS_REGION || AWS_REGION || AWS_DEFAULT_REGION,
     accessKeyId: DULLAHAN_RUNNER_AWS_LAMBDA_AWS_ACCESS_KEY_ID || AWS_ACCESS_KEY_ID,


### PR DESCRIPTION
This allows us to remove a Kaartje2go-specific configuration
where the runner would throttle the starting of slaves with
a static rate-limiter; it is now an option with a value X
meaning "Start X slaves per second, up to the maximum concurrency."

