### PR TITLE
feat: allow tests to be passed as instances

### DIFF
--- a/__snapshots__/env_nodejs/exports.ts.snap
+++ b/__snapshots__/env_nodejs/exports.ts.snap
@@ -81,6 +81,8 @@ exports[`@k2g/dullahan getElementProperties should remain the same 1`] = `[Funct
 
 exports[`@k2g/dullahan getElementStyles should remain the same 1`] = `[Function]`;
 
+exports[`@k2g/dullahan hasProperty should remain the same 1`] = `[Function]`;
+
 exports[`@k2g/dullahan isAbsolutePath should remain the same 1`] = `[Function]`;
 
 exports[`@k2g/dullahan isDullahanConfig should remain the same 1`] = `[Function]`;

--- a/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambda.ts
+++ b/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambda.ts
@@ -8,8 +8,10 @@ import {
     DullahanClient,
     DullahanError,
     DullahanFunctionEndCall,
-    DullahanRunner, DullahanTest,
-    DullahanTestEndCall, hasProperty,
+    DullahanRunner,
+    DullahanTest,
+    DullahanTestEndCall,
+    hasProperty,
     tryIgnore,
 } from "@k2g/dullahan";
 import { Lambda } from "aws-sdk";

--- a/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambda.ts
+++ b/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambda.ts
@@ -1,9 +1,7 @@
-import {
-    DullahanRunnerAwsLambdaDefaultOptions,
-    DullahanRunnerAwsLambdaUserOptions,
-} from "./DullahanRunnerAwsLambdaOptions";
-import * as fastGlob from "fast-glob";
-import asyncPool from "tiny-async-pool";
+import * as fastGlob from 'fast-glob';
+import asyncPool from 'tiny-async-pool';
+import {Lambda} from 'aws-sdk';
+import {RateLimit} from 'async-sema';
 import {
     DullahanClient,
     DullahanError,
@@ -13,32 +11,24 @@ import {
     DullahanTestEndCall,
     hasProperty,
     tryIgnore,
-} from "@k2g/dullahan";
-import { Lambda } from "aws-sdk";
+} from '@k2g/dullahan';
+import {
+    DullahanRunnerAwsLambdaDefaultOptions,
+    DullahanRunnerAwsLambdaUserOptions
+} from './DullahanRunnerAwsLambdaOptions';
 
-import { RateLimit } from "async-sema";
+export default class DullahanRunnerAwsLambda extends DullahanRunner<DullahanRunnerAwsLambdaUserOptions, typeof DullahanRunnerAwsLambdaDefaultOptions> {
 
-interface Test {
-    functionEndCalls?: DullahanFunctionEndCall[];
-    testEndCalls?: DullahanTestEndCall[];
-}
-
-export default class DullahanRunnerAwsLambda extends DullahanRunner<
-    DullahanRunnerAwsLambdaUserOptions,
-    typeof DullahanRunnerAwsLambdaDefaultOptions
-> {
     private hasStopSignal = false;
 
-    private readonly lambda = this.options.useAccessKeys
-        ? new Lambda({
-              accessKeyId: this.options.accessKeyId,
-              secretAccessKey: this.options.secretAccessKey,
-              httpOptions: this.options.httpOptions,
-              region: this.options.region,
-          })
-        : new Lambda({
-              httpOptions: this.options.httpOptions,
-          });
+    private readonly lambda = this.options.useAccessKeys ? new Lambda({
+        accessKeyId: this.options.accessKeyId,
+        secretAccessKey: this.options.secretAccessKey,
+        httpOptions: this.options.httpOptions,
+        region: this.options.region,
+    }) : new Lambda({
+        httpOptions: this.options.httpOptions,
+    });
 
     public constructor(args: {
         client: DullahanClient;
@@ -51,121 +41,102 @@ export default class DullahanRunnerAwsLambda extends DullahanRunner<
     }
 
     public async start(): Promise<void> {
-        return this.options.role === "master"
-            ? this.startMaster()
-            : this.startSlave();
+        return this.options.role === "master" ? this.startMaster() : this.startSlave();
     }
 
     public async stop(earlyTermination = false): Promise<void> {
         if (earlyTermination) {
-            console.log(
-                "set hasStop signal to end loop early because early termination is true"
-            );
             this.hasStopSignal = true;
         }
     }
 
-    private async startMaster(): Promise<void> {
-        const {
-            client,
-            options,
-            rootDirectories,
-            includeGlobs,
-            excludeGlobs,
-            includeRegexes,
-            excludeRegexes,
-        } = this;
-        const {
-            tests,
-            maxConcurrency,
-            rateLimitConcurrency,
-            minSuccesses,
-            maxAttempts,
-            failFast,
-            testPredicate,
-        } = options;
+    private async getTestDataFromFiles(): Promise<{
+        file: string;
+        successes: number;
+        failures: number;
+    }[]> {
+        const {client, options, rootDirectories, includeGlobs, excludeGlobs, includeRegexes, excludeRegexes} = this;
+        const {testPredicate} = options;
 
-        let testFiles: {
-            file: string;
-            successes: number;
-            failures: number;
-        }[] | {
-            testIndex: number;
-            successes: number;
-            failures: number;
-        }[] = [];
-
-        if (tests?.length) {
-            testFiles = (await Promise.all(tests.map(async (test: DullahanTest, testIndex: number) => {
-                const accepted = await testPredicate('', test);
-                return {testIndex, accepted};
-            }))).filter(({accepted}) => accepted).map(({testIndex}) => ({
-                testIndex,
-                successes: 0,
-                failures: 0,
-            }));
-        } else {
-            if (includeGlobs.length === 0) {
-                includeGlobs.push("**/*");
-            }
-
-            console.log("Dullahan Runner AWS Lambda - finding tests");
-
-            const searchResults = await Promise.all(rootDirectories.map((rootDirectory) => fastGlob(includeGlobs, {
-                cwd: rootDirectory,
-                ignore: excludeGlobs,
-                absolute: true,
-                dot: true,
-            })));
-
-            const filteredSearchResults = searchResults.flat().filter((file) => (
-                (!includeRegexes.length || includeRegexes.some((iRegex) => iRegex.test(file)))
-                && (!excludeRegexes.length || !excludeRegexes.some((eRegex) => eRegex.test(file)))
-            ));
-
-            testFiles = (await Promise.all(filteredSearchResults.map(async (file: string) => {
-                const instance = client.getTestInstance(file);
-                const accepted = !!instance && (await testPredicate(file, instance.test));
-                return {file, accepted};
-            }))).filter(({accepted}) => accepted).map(({file}) => ({
-                file,
-                successes: 0,
-                failures: 0,
-            }));
+        if (includeGlobs.length === 0) {
+            includeGlobs.push("**/*");
         }
 
+        const searchResults = await Promise.all(rootDirectories.map((rootDirectory) => fastGlob(includeGlobs, {
+            cwd: rootDirectory,
+            ignore: excludeGlobs,
+            absolute: true,
+            dot: true
+        })));
+
+        const filteredSearchResults = searchResults.flat().filter((file) => (
+            (!includeRegexes.length || includeRegexes.some((iRegex) => iRegex.test(file)))
+            && (!excludeRegexes.length || !excludeRegexes.some((eRegex) => eRegex.test(file)))
+        ));
+
+        return (await Promise.all(filteredSearchResults.map(async (file: string) => {
+            const instance = client.getTestInstance(file);
+            const accepted = !!instance && (await testPredicate(file, instance.test));
+            return {file, accepted};
+        }))).filter(({accepted}) => accepted).map(({file}) => ({
+            file,
+            successes: 0,
+            failures: 0
+        }));
+    }
+
+    private async getTestDataFromInstances(): Promise<{
+        testIndex: number;
+        successes: number;
+        failures: number;
+    }[]> {
+        const {options} = this;
+        const {tests = [], testPredicate} = options;
+
+        return (await Promise.all(tests.map(async (test: DullahanTest, testIndex: number) => {
+            const accepted = await testPredicate('', test);
+            return {testIndex, accepted};
+        }))).filter(({accepted}) => accepted).map(({testIndex}) => ({
+            testIndex,
+            successes: 0,
+            failures: 0
+        }));
+    }
+
+    private async startMaster(): Promise<void> {
+        const {options} = this;
+        const {tests, maxConcurrency, rateLimitConcurrency, minSuccesses, maxAttempts, failFast} = options;
+
+        const allTestData: (({
+            file: string;
+        } | {
+            testIndex: number;
+        }) & {
+            successes: number;
+            failures: number;
+        })[] = await (tests?.length ? this.getTestDataFromInstances() : this.getTestDataFromFiles());
 
         let failureCount = 0;
-        const nextPool = [...testFiles];
+        const nextPool = [...allTestData];
         const rateLimit = rateLimitConcurrency === Infinity ? null
             : RateLimit(rateLimitConcurrency, {uniformDistribution: true});
 
-        console.log(
-            `Dullahan Runner AWS Lambda - found ${testFiles.length} valid test files`
-        );
+        console.log(`Dullahan Runner AWS Lambda - found ${allTestData.length} valid test files`);
         console.log(`Running tests with concurrency ${maxConcurrency}`);
 
         do {
             const currentPool = nextPool.splice(0, nextPool.length);
 
-            await asyncPool(maxConcurrency, currentPool, async (testData: {
-                file: string;
-                successes: number;
-                failures: number;
-            } | {
-                testIndex: number;
-                successes: number;
-                failures: number;
-            }) => {
+            await asyncPool(maxConcurrency, currentPool, async (testData: typeof allTestData[0]) => {
                 if (this.hasStopSignal) {
                     return;
                 }
 
                 rateLimit && await rateLimit();
 
-                const success = await this.processFile(hasProperty(testData, 'file') ? testData.file : testData.testIndex).catch((error) => {
+                const test = hasProperty(testData, 'file') ? testData.file : testData.testIndex;
+                const success = await this.processFile(test).catch((error) => {
                     console.error(error);
-
                     return false;
                 });
                 success ? testData.successes++ : testData.failures++;
@@ -174,10 +145,8 @@ export default class DullahanRunnerAwsLambda extends DullahanRunner<
                     return;
                 }
 
-                const hasMoreAttempts =
-                    testData.successes + testData.failures < maxAttempts;
-                const couldStillPass =
-                    maxAttempts - testData.failures >= minSuccesses;
+                const hasMoreAttempts = testData.successes + testData.failures < maxAttempts;
+                const couldStillPass = maxAttempts - testData.failures >= minSuccesses;
 
                 if (hasMoreAttempts && couldStillPass) {
                     nextPool.push(testData);
@@ -190,8 +159,8 @@ export default class DullahanRunnerAwsLambda extends DullahanRunner<
     }
 
     private async startSlave(): Promise<void> {
-        const { client, options } = this;
-        const { file, test: testInstance } = options.slaveOptions;
+        const {client, options} = this;
+        const {file, test: testInstance} = options.slaveOptions;
 
         const instance = client.getTestInstance(testInstance ?? file!);
 
@@ -199,7 +168,7 @@ export default class DullahanRunnerAwsLambda extends DullahanRunner<
             return;
         }
 
-        const { testId, test, adapter, api } = instance;
+        const {testId, test, adapter, api} = instance;
 
         const timeStart = Date.now();
         const testName = test.name;
@@ -241,48 +210,43 @@ export default class DullahanRunnerAwsLambda extends DullahanRunner<
     }
 
     private async processFile(file: string | number): Promise<boolean> {
-        const { lambda, client, options } = this;
-        const { slaveQualifier, slaveFunctionName, slaveOptions } = options;
+        const {lambda, client, options} = this;
+        const {slaveQualifier, slaveFunctionName, slaveOptions} = options;
 
-        const data = await lambda
-            .invoke({
-                Qualifier: slaveQualifier!,
-                FunctionName: slaveFunctionName!,
-                Payload: JSON.stringify({
-                    body: JSON.stringify({
-                        ...slaveOptions,
-                        file: typeof file === 'string' ? file : undefined,
-                        testIndex: typeof file === 'number' ? file : undefined,
-                    })
+        const data = await lambda.invoke({
+            Qualifier: slaveQualifier!,
+            FunctionName: slaveFunctionName!,
+            Payload: JSON.stringify({
+                body: JSON.stringify({
+                    ...slaveOptions,
+                    file: typeof file === 'string' ? file : undefined,
+                    testIndex: typeof file === 'number' ? file : undefined,
                 })
             })
-            .promise();
+        }).promise();
 
-        const { Payload } = data;
+        const {Payload} = data;
 
         // If the payload is not of type string, it cannot be parsed.
-        if (typeof Payload !== "string") {
-            console.error(
-                `Invoked test returned incorrect Payload of type ${typeof Payload}`
-            );
+        if (typeof Payload !== 'string') {
+            console.error(`Invoked test returned incorrect Payload of type ${typeof Payload}`);
             return false;
         }
         try {
-            const parsedPayload = JSON.parse(
-                JSON.parse(Payload as string)
-            ) as Test;
-            const { functionEndCalls, testEndCalls } = parsedPayload;
+            const parsedPayload = JSON.parse(JSON.parse(Payload as string)) as {
+                functionEndCalls?: DullahanFunctionEndCall[];
+                testEndCalls?: DullahanTestEndCall[];
+            };
+            const {functionEndCalls, testEndCalls} = parsedPayload;
             const testEndCall = testEndCalls && testEndCalls[0];
 
-            functionEndCalls?.forEach((functionEndCall) =>
-                client.emitFunctionEnd(functionEndCall)
-            );
+            functionEndCalls?.forEach((functionEndCall) => client.emitFunctionEnd(functionEndCall));
             testEndCall && client.emitTestEnd(testEndCall);
 
             return !testEndCall?.error;
         } catch (e) {
-            console.info("Failed with Payload", Payload);
-            console.info("Failed with data", JSON.stringify(data));
+            console.info('Failed with Payload', Payload);
+            console.info('Failed with data', JSON.stringify(data));
             console.error(e);
             return false;
         }

--- a/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambdaOptions.ts
+++ b/packages/dullahan-runner-aws-lambda/src/DullahanRunnerAwsLambdaOptions.ts
@@ -1,4 +1,4 @@
-import {DullahanRunnerDefaultOptions, DullahanRunnerUserOptions} from '@k2g/dullahan';
+import {DullahanRunnerDefaultOptions, DullahanRunnerUserOptions, DullahanTest} from '@k2g/dullahan';
 import { HTTPOptions } from 'aws-sdk';
 
 const {
@@ -10,6 +10,7 @@ const {
 } = process.env;
 
 export type DullahanRunnerAwsLambdaUserOptions = Partial<DullahanRunnerUserOptions & {
+    tests?: DullahanTest[];
     accessKeyId: string;
     httpOptions?: HTTPOptions;
     maxConcurrency: number;
@@ -21,6 +22,11 @@ export type DullahanRunnerAwsLambdaUserOptions = Partial<DullahanRunnerUserOptio
     slaveQualifier: string;
     slaveOptions: {
         file: string;
+        test?: DullahanTest;
+        [key: string]: unknown;
+    } | {
+        file?: undefined;
+        test: DullahanTest;
         [key: string]: unknown;
     };
     useAccessKeys: boolean;

--- a/packages/dullahan-runner-development/src/DullahanRunnerDevelopment.ts
+++ b/packages/dullahan-runner-development/src/DullahanRunnerDevelopment.ts
@@ -23,8 +23,8 @@ export default class DullahanRunnerDevelopment extends DullahanRunner<DullahanRu
     private isBusy = false;
 
     private instance?: ({
-        api: DullahanApi<never, never>;
-        adapter: DullahanAdapter<never, never>;
+        api: DullahanApi<any, any>;
+        adapter: DullahanAdapter<any, any>;
         test: DullahanTest;
     });
 
@@ -102,8 +102,8 @@ export default class DullahanRunnerDevelopment extends DullahanRunner<DullahanRu
 
     private async processFile(file: string, instance: {
         testId: string;
-        api: DullahanApi<never, never>;
-        adapter: DullahanAdapter<never, never>;
+        api: DullahanApi<any, any>;
+        adapter: DullahanAdapter<any, any>;
         test: DullahanTest;
     }): Promise<boolean> {
         const {client} = this;

--- a/packages/dullahan/__tests__/ensureScopedOptions.ts
+++ b/packages/dullahan/__tests__/ensureScopedOptions.ts
@@ -16,7 +16,7 @@ describe('ensureScopedOptions', () => {
     });
 
     it('should throw an error if the argument is not a type we can work with', () => {
-        const message = 'Expected input to be a string or an array containing a string and an object';
+        const message = 'Expected input to be a string/constructor or an array containing a string/constructor and an object';
 
         expect(ensureScopedOptions.bind(null, undefined)).toThrow(message);
         expect(ensureScopedOptions.bind(null, null as unknown as undefined)).toThrow(message);

--- a/packages/dullahan/src/DullahanClient.ts
+++ b/packages/dullahan/src/DullahanClient.ts
@@ -21,30 +21,8 @@ import {
     StoredArtifact
 } from './nodejs_helpers';
 import {DullahanRunner} from './runner';
-
-type ApiContructor = new (args: {
-    testId: string;
-    test: DullahanTest<never>;
-    adapter: DullahanAdapter<never, never>;
-    client: DullahanClient;
-    userOptions: object;
-}) => DullahanApi<never, never>;
-
-type AdapterConstructor = new (args: {
-    testId: string;
-    client: DullahanClient;
-    userOptions: object;
-}) => DullahanAdapter<never, never>;
-
-type RunnerConstructor = new (args: {
-    client: DullahanClient;
-    userOptions: object;
-}) => DullahanRunner<never, never>;
-
-type PluginConstructor = new (args: {
-    client: DullahanClient;
-    userOptions: object;
-}) => DullahanPlugin<never, never>;
+import {AdapterConstructor, ApiContructor, PluginConstructor, RunnerConstructor} from "./nodejs_helpers/types";
+import {DullahanError} from "./DullahanError";
 
 export class DullahanClient {
 
@@ -54,9 +32,9 @@ export class DullahanClient {
 
     public readonly config: DullahanConfig;
 
-    private readonly runner: DullahanRunner<never, never>;
+    private readonly runner: DullahanRunner<any, any>;
 
-    private readonly plugins: DullahanPlugin<never, never>[];
+    private readonly plugins: DullahanPlugin<any, any>[];
 
     private readonly storedArtifactPromises: Promise<StoredArtifact>[] = [];
 
@@ -66,22 +44,22 @@ export class DullahanClient {
     private readonly testEndPromises: Promise<DullahanTestEndCall>[] = [];
 
     public constructor(config: DullahanConfig) {
-        const Api = requireDependency(config.api[0], {
+        const Api = typeof config.api[0] === 'string' ? requireDependency(config.api[0], {
             expectedName: /^DullahanApi/i
-        }) as ApiContructor;
+        }) as ApiContructor : config.api[0];
 
-        const Adapter = requireDependency(config.adapter[0], {
+        const Adapter = typeof config.adapter[0] === 'string'?requireDependency(config.adapter[0], {
             expectedName: /^DullahanAdapter/i
-        }) as AdapterConstructor;
+        }) as AdapterConstructor : config.adapter[0];
 
-        const Runner = requireDependency(config.runner[0], {
+        const Runner = typeof config.runner[0] === 'string' ? requireDependency(config.runner[0], {
             expectedName: /^DullahanRunner/i
-        }) as RunnerConstructor;
+        }) as RunnerConstructor : config.runner[0];
 
-        const plugins = config.plugins.map(([nameOrPath, userOptions]: DullahanScopedOptions) => {
-            const Plugin = requireDependency(nameOrPath, {
+        const plugins = config.plugins.map(([nameOrPath, userOptions]: DullahanScopedOptions<PluginConstructor>) => {
+            const Plugin = typeof nameOrPath === 'string' ? requireDependency(nameOrPath, {
                 expectedName: /^DullahanPlugin/i
-            }) as PluginConstructor;
+            }) as PluginConstructor : nameOrPath;
 
             return new Plugin({
                 client: this,
@@ -104,6 +82,10 @@ export class DullahanClient {
     public reloadApi(clearCache?: 'shallow' | 'recursive'): void {
         const {api} = this.config;
 
+        if (typeof api[0] !== 'string') {
+            throw new DullahanError('Cannot reload API: A file path is needed, but a constructor was provided.');
+        }
+
         this.Api = requireDependency(api[0], {
             clearCache,
             expectedName: /^DullahanApi/i
@@ -113,22 +95,26 @@ export class DullahanClient {
     public reloadAdapter(clearCache?: 'shallow' | 'recursive'): void {
         const {adapter} = this.config;
 
+        if (typeof adapter[0] !== 'string') {
+            throw new DullahanError('Cannot reload Adapter: A file path is needed, but a constructor was provided.');
+        }
+
         this.Adapter = requireDependency(adapter[0], {
             clearCache,
             expectedName: /^DullahanAdapter/i
         }) as AdapterConstructor;
     }
 
-    public getTestInstance(file: string, clearCache?: 'shallow' | 'recursive'): {
+    public getTestInstance(file: string | DullahanTest, clearCache?: 'shallow' | 'recursive'): {
         testId: string;
-        api: DullahanApi<never, never>;
-        adapter: DullahanAdapter<never, never>;
+        api: DullahanApi<any, any>;
+        adapter: DullahanAdapter<any, any>;
         test: DullahanTest;
     } | null {
         const {config, Api, Adapter} = this;
 
-        const testId = createHash('sha256').update(file).digest('hex');
-        const test = requireDependency(file, {clearCache}) as Partial<DullahanTest>;
+        const testId = createHash('sha256').update(file.toString()).digest('hex');
+        const test = typeof file === 'string' ? requireDependency(file, {clearCache}) as Partial<DullahanTest> : file;
 
         if (!isValidTest(test)) {
             return null;

--- a/packages/dullahan/src/DullahanConfig.ts
+++ b/packages/dullahan/src/DullahanConfig.ts
@@ -1,8 +1,20 @@
+import {
+    AdapterConstructor,
+    ApiContructor, DependencyPath,
+    hasProperty,
+    PluginConstructor,
+    RunnerConstructor
+} from './nodejs_helpers/types';
+
 export type DullahanConfig = {
-    api: [string, object];
-    adapter: [string, object];
-    runner: [string, object];
-    plugins: [string, object][];
+    api: [DependencyPath | ApiContructor, object];
+    adapter: [DependencyPath | AdapterConstructor, object];
+    runner: [DependencyPath | RunnerConstructor, object];
+    plugins: [DependencyPath | PluginConstructor, object][];
 }
 
-export const isDullahanConfig = (input: any): input is DullahanConfig => true;
+export const isDullahanConfig = (input: unknown): input is DullahanConfig => {
+    // It's not perfect, but it at least verifies the shape of the input
+    return hasProperty(input, 'api') && hasProperty(input, 'adapter')
+        && hasProperty(input, 'runner') && hasProperty(input, 'plugins');
+};

--- a/packages/dullahan/src/adapter/DullahanAdapter.ts
+++ b/packages/dullahan/src/adapter/DullahanAdapter.ts
@@ -15,7 +15,7 @@ export type DullahanAdapterArguments<
     testId: string;
     client: DullahanClient;
     userOptions: DullahanAdapterSubclassUserOptions;
-    defaultOptions: DullahanAdapterSubclassDefaultOptions;
+    defaultOptions?: DullahanAdapterSubclassDefaultOptions;
 };
 
 export abstract class DullahanAdapter<
@@ -31,7 +31,7 @@ export abstract class DullahanAdapter<
         testId,
         client,
         userOptions,
-        defaultOptions,
+        defaultOptions = DullahanAdapterDefaultOptions as DullahanAdapterSubclassDefaultOptions,
     }: DullahanAdapterArguments<
         DullahanAdapterSubclassUserOptions,
         DullahanAdapterSubclassDefaultOptions

--- a/packages/dullahan/src/api/DullahanApi.ts
+++ b/packages/dullahan/src/api/DullahanApi.ts
@@ -15,9 +15,9 @@ export type DullahanApiArguments<
     testId: string;
     test: DullahanTest;
     client: DullahanClient;
-    adapter: DullahanAdapter<never, never>;
+    adapter: DullahanAdapter<any, any>;
     userOptions: DullahanApiSubclassUserOptions;
-    defaultOptions: DullahanApiSubclassDefaultOptions;
+    defaultOptions?: DullahanApiSubclassDefaultOptions;
 };
 
 export class DullahanApi<
@@ -27,7 +27,7 @@ export class DullahanApi<
 
     protected readonly client: unknown;
 
-    protected readonly adapter: DullahanAdapter<never, never>;
+    protected readonly adapter: DullahanAdapter<any, any>;
 
     protected readonly test: DullahanTest;
 

--- a/packages/dullahan/src/nodejs_helpers/artifacts.ts
+++ b/packages/dullahan/src/nodejs_helpers/artifacts.ts
@@ -40,8 +40,8 @@ export const saveArtifactToFile = async (artifact: Artifact): Promise<URL> => {
     return pathToFileURL(filePath);
 };
 
-export const saveArtifactToRemotes = async (artifact: Artifact, plugins: DullahanPlugin<never, never>[]): Promise<URL[]> => {
-    const uploads = plugins.map(async (plugin: DullahanPlugin<never, never>) => plugin.uploadArtifact(artifact));
+export const saveArtifactToRemotes = async (artifact: Artifact, plugins: DullahanPlugin<any, any>[]): Promise<URL[]> => {
+    const uploads = plugins.map(async (plugin: DullahanPlugin<any, any>) => plugin.uploadArtifact(artifact));
 
     return (await Promise.all(uploads)).filter((url): url is URL => !!url);
 };

--- a/packages/dullahan/src/nodejs_helpers/options.ts
+++ b/packages/dullahan/src/nodejs_helpers/options.ts
@@ -1,25 +1,30 @@
 import {DullahanError} from '../DullahanError';
+import {DependencyPath} from "./types";
 
-export type DullahanScopedOptions<T extends object = object> = [string, Partial<T>];
+export type DullahanScopedOptions<S = string, T extends object = object> = [S | DependencyPath, Partial<T>];
 
 export const ensureArray = <T>(input?: null | T | undefined[] | null[] | T[] | (undefined | null | T)[]): T[] => {
     const array = input ? Array.isArray(input) ? input : [input] : [];
     return array.filter<T>((entry?: T | null): entry is T => entry !== null && entry !== undefined);
 };
 
-export const ensureScopedOptions = <T extends object>(input?: unknown): DullahanScopedOptions<T> => {
+export const ensureScopedOptions = <S = string, T extends object = object>(input?: unknown): DullahanScopedOptions<S, T> => {
     if (typeof input === 'string') {
         return [input, {}];
     }
 
+    if (typeof input === 'function') {
+        return [input as unknown as S, {}];
+    }
+
     if (!Array.isArray(input)) {
-        throw new DullahanError('Expected input to be a string or an array containing a string and an object');
+        throw new DullahanError('Expected input to be a string/constructor or an array containing a string/constructor and an object');
     }
 
     const [path, options] = input;
 
-    if (typeof path !== 'string' || options && typeof options !== 'object') {
-        throw new DullahanError('Expected input to be a string or an array containing a string and an object');
+    if (typeof path !== 'string' && typeof path !== 'function' || options && typeof options !== 'object') {
+        throw new DullahanError('Expected input to be a string/constructor or an array containing a string/constructor and an object');
     }
 
     return [

--- a/packages/dullahan/src/nodejs_helpers/types.ts
+++ b/packages/dullahan/src/nodejs_helpers/types.ts
@@ -1,3 +1,10 @@
+import {DullahanTest} from "../DullahanTest";
+import {DullahanAdapter, DullahanAdapterArguments} from "../adapter/DullahanAdapter";
+import {DullahanApi, DullahanApiArguments} from "../api/DullahanApi";
+import {DullahanClient} from "../DullahanClient";
+import {DullahanPlugin} from "../DullahanPlugin";
+import {DullahanRunner, DullahanRunnerArguments} from "../runner/DullahanRunner";
+
 export type AbsolutePath = string;
 export type RelativePath = string;
 export type ModulePath = string;
@@ -39,11 +46,26 @@ export const isRelativePath = (path: string): path is RelativePath => {
  * Does not check if the file or directory actually exists.
  *
  * @example
- * import 'jquery';
- * import 'jquery/file';
+ * import '@k2g/dullahan';
+ * import '@k2g/dullahan/file';
  *
  * @param path Any string that could be used in a require call.
  */
 export const isModulePath = (path: string): path is ModulePath => {
     return !!path.length && !isRelativePath(path) && !isAbsolutePath(path);
+};
+
+export type ApiContructor = new (args: DullahanApiArguments<any, any>) => DullahanApi<any, any>;
+
+export type AdapterConstructor = new (args: DullahanAdapterArguments<any, any>) => DullahanAdapter<any, any>;
+
+export type RunnerConstructor = new (args: DullahanRunnerArguments<any, any>) => DullahanRunner<any, any>;
+
+export type PluginConstructor = new (args: {
+    client: DullahanClient;
+    userOptions: object;
+}) => DullahanPlugin<any, any>;
+
+export const hasProperty = <O, P extends PropertyKey>(object: O, property: P): object is O & Record<P, unknown> => {
+    return object !== null && typeof object === 'object' && Object.prototype.hasOwnProperty.call(object, property);
 };

--- a/packages/dullahan/src/runner/DullahanRunner.ts
+++ b/packages/dullahan/src/runner/DullahanRunner.ts
@@ -11,7 +11,7 @@ export type DullahanRunnerArguments<DullahanRunnerSubclassUserOptions extends Du
     DullahanRunnerSubclassDefaultOptions extends typeof DullahanRunnerDefaultOptions> = {
     client: DullahanClient;
     userOptions: DullahanRunnerSubclassUserOptions;
-    defaultOptions: DullahanRunnerSubclassDefaultOptions;
+    defaultOptions?: DullahanRunnerSubclassDefaultOptions;
 };
 
 export abstract class DullahanRunner<DullahanRunnerSubclassUserOptions extends DullahanRunnerUserOptions,
@@ -34,7 +34,7 @@ export abstract class DullahanRunner<DullahanRunnerSubclassUserOptions extends D
     public constructor({
                            client,
                            userOptions,
-                           defaultOptions
+                           defaultOptions = DullahanRunnerDefaultOptions as DullahanRunnerSubclassDefaultOptions
                        }: DullahanRunnerArguments<DullahanRunnerSubclassUserOptions, DullahanRunnerSubclassDefaultOptions>) {
         this.client = client;
         this.options = assignDeep({}, defaultOptions, userOptions);


### PR DESCRIPTION
On AWS Lambda, building and deploying your Dullahan functions can be
quite tricky depending on your setup. Allowing files to be passed as
constructors or instances allows tools like webpack to bundle everything
into one convenient file for you to deploy on AWS Lambda.

