### PR TITLE
feat: add support for inlined templates

### DIFF
--- a/packages/dullahan-plugin-report-html/src/DullahanPluginReportHtml.ts
+++ b/packages/dullahan-plugin-report-html/src/DullahanPluginReportHtml.ts
@@ -44,7 +44,7 @@ export default class DullahanPluginReportHtml extends DullahanPlugin<
 
         if (!this.options.template) {
             this.filename = resolvePath(__dirname, '../template/report.ejs');
-        } else if (this.options.template.includes('\n')) {
+        } else if (this.options.template.includes('<')) {
             this.filename = 'report.ejs';
             this.templatePromise = Promise.resolve(this.options.template);
         } else if (isRelativePath(this.options.template)) {

--- a/packages/dullahan-plugin-report-html/src/DullahanPluginReportHtml.ts
+++ b/packages/dullahan-plugin-report-html/src/DullahanPluginReportHtml.ts
@@ -17,22 +17,21 @@ import { readFile } from "fs";
 import {
     Artifact,
     DullahanClient,
+    DullahanError,
     DullahanFunctionEndCall,
     DullahanPlugin,
     DullahanTestEndCall,
+    isAbsolutePath,
+    isRelativePath
 } from "@k2g/dullahan";
 export default class DullahanPluginReportHtml extends DullahanPlugin<
     DullahanPluginReportHtmlUserOptions,
     typeof DullahanPluginReportHtmlDefaultOptions
 > {
-    private readonly filename = this.options.template
-        ? resolvePath(process.cwd(), this.options.template)
-        : resolvePath(__dirname, "../template/report.ejs");
 
-    private startTime:number;
-    private readonly templatePromise = promisify(readFile)(
-        this.filename
-    ).then((buffer) => buffer.toString());
+    private startTime: number;
+    private readonly filename;
+    private readonly templatePromise: Promise<string>;
 
     public constructor(args: {
         client: DullahanClient;
@@ -42,6 +41,21 @@ export default class DullahanPluginReportHtml extends DullahanPlugin<
             ...args,
             defaultOptions: DullahanPluginReportHtmlDefaultOptions,
         });
+
+        if (!this.options.template) {
+            this.filename = resolvePath(__dirname, '../template/report.ejs');
+        } else if (this.options.template.includes('\n')) {
+            this.filename = 'report.ejs';
+            this.templatePromise = Promise.resolve(this.options.template);
+        } else if (isRelativePath(this.options.template)) {
+            this.filename = resolvePath(process.cwd(), this.options.template)
+        } else if (isAbsolutePath(this.options.template)) {
+            this.filename = resolvePath(this.options.template);
+        } else {
+            throw new DullahanError('Loading templates from node_modules is not (yet) supported');
+        }
+
+        this.templatePromise ??= promisify(readFile)(this.filename).then((buffer) => buffer.toString());
         this.startTime = Date.now();
     }
 

--- a/packages/dullahan-plugin-report-html/src/DullahanPluginReportHtmlOptions.ts
+++ b/packages/dullahan-plugin-report-html/src/DullahanPluginReportHtmlOptions.ts
@@ -1,4 +1,4 @@
-import {DullahanPluginUserOptions, DullahanPluginDefaultOptions} from '@k2g/dullahan';
+import {DullahanPluginUserOptions, DullahanPluginDefaultOptions, DependencyPath} from '@k2g/dullahan';
 
 export type DullahanPluginReportHtmlUserOptions = Partial<DullahanPluginUserOptions & {
     reportTitle: string;
@@ -9,7 +9,7 @@ export type DullahanPluginReportHtmlUserOptions = Partial<DullahanPluginUserOpti
     colorUnstable: string;
     colorSlow: string;
     colorSuccessful: string;
-    template: string;
+    template: DependencyPath | string;
 }>;
 
 export const DullahanPluginReportHtmlDefaultOptions = {


### PR DESCRIPTION
This change allows compiled versions of the plugins to work with
an inlined version as option. It's not perfect, but it's a good step in
the right direction.

