### PR TITLE
fix: generate test ids based on test content

### DIFF
--- a/packages/dullahan/src/DullahanClient.ts
+++ b/packages/dullahan/src/DullahanClient.ts
@@ -113,7 +113,7 @@ export class DullahanClient {
     } | null {
         const {config, Api, Adapter} = this;
 
-        const testId = createHash('sha256').update(file.toString()).digest('hex');
+        const testId = createHash('sha256').update(JSON.stringify(file)).digest('hex');
         const test = typeof file === 'string' ? requireDependency(file, {clearCache}) as Partial<DullahanTest> : file;
 
         if (!isValidTest(test)) {

--- a/packages/dullahan/src/DullahanTest.ts
+++ b/packages/dullahan/src/DullahanTest.ts
@@ -23,6 +23,22 @@ export class DullahanTest<Api extends DullahanApi<DullahanApiUserOptions, Dullah
         this.disabled = !!disabled;
         this.run = run;
     }
+
+    public toJSON(): {
+        name: string;
+        tags: string[];
+        disabled: boolean;
+        run: string;
+    } {
+        const {name, tags, disabled, run} = this;
+
+        return {
+          name,
+          tags,
+          disabled,
+          run: run.toString()
+        };
+    }
 }
 
 export const isValidTest = (test: Partial<DullahanTest>): test is DullahanTest => {


### PR DESCRIPTION
The previous solution didn't exactly work as expected,
as the source for the hash was always [object Object]
and thus resulted in all tests having the same id if
provided through instances

