### PR TITLE
improve goto

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
         "extends": [
             "config:base"
         ],
+        "ignoreDeps": ["puppeteer"],
         "rangeStrategy": "auto",
         "packageRules": [
             {

--- a/packages/dullahan-adapter-puppeteer/package.json
+++ b/packages/dullahan-adapter-puppeteer/package.json
@@ -14,6 +14,6 @@
   },
   "dependencies": {
     "@k2g/dullahan": "^1.0.0-alpha.149",
-    "puppeteer": "15.1"
+    "puppeteer": "14.1"
   }
 }

--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
@@ -1017,13 +1017,11 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
         }
 
-        await page.evaluate(`window.location = ${JSON.stringify(url)}`);
+        const waitUntil = readyState === 'interactive' ? 'domcontentloaded' : 'load';
 
-        await tryX(2, async () => {
-            await page.waitForFunction(waitForReadyState, {timeout: timeout / 2}, {
-                readyState,
-                timeout: timeout / 2
-            });
+        await page.goto(url, {
+            waitUntil,
+            timeout
         });
     }
 

--- a/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
+++ b/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
@@ -1240,16 +1240,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
         }
 
-        await driver.executeScript<void>(`window.location = ${JSON.stringify(url)}`);
-
-        await tryX(2, async () => {
-            await sleep(100);
-
-            await driver.wait(() => driver.executeScript<boolean>(waitForReadyState, {
-                readyState,
-                timeout: timeout / 2
-            }), timeout / 2);
-        });
+        await driver.navigate().to(url);
     }
 
     public async waitForElementPresent(selector: string, options: {

--- a/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
+++ b/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
@@ -1240,7 +1240,7 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
         }
 
-        await driver.navigate().to(url);
+        await driver.get(url);
     }
 
     public async waitForElementPresent(selector: string, options: {

--- a/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
+++ b/packages/dullahan-adapter-selenium-4/src/DullahanAdapterSelenium4.ts
@@ -1240,6 +1240,16 @@ export default class DullahanAdapterSelenium4 extends DullahanAdapter<DullahanAd
             throw new AdapterError(DullahanErrorMessage.NO_BROWSER);
         }
 
+        const capabilities  = await driver.getCapabilities();
+        // https://www.selenium.dev/documentation/webdriver/capabilities/shared/#pageloadstrategy
+        if (readyState === 'interactive') {
+            // DOM access is ready, but other resources like images may still be loading
+            capabilities.setPageLoadStrategy('eager');
+        } else {
+            // Used by default, waits for all resources to download
+            capabilities.setPageLoadStrategy('normal');
+        }
+
         await driver.get(url);
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4413,10 +4413,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-devtools-protocol@0.0.1011705:
-  version "0.0.1011705"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1011705.tgz#2582ed29f84848df83fba488122015540a744539"
-  integrity sha512-OKvTvu9n3swmgYshvsyVHYX0+aPzCoYUnyXUacfQMmFtBtBKewV/gT4I9jkAbpTqtTi2E4S9MXLlvzBDUlqg0Q==
+devtools-protocol@0.0.982423:
+  version "0.0.982423"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.982423.tgz#39ac3791d4c5b90ebb416d4384663b7b0cc44154"
+  integrity sha512-FnVW2nDbjGNw1uD/JRC+9U5768W7e1TfUwqbDTcSsAu1jXFjITSX8w3rkW5FEpHRMPPGpvNSmO1pOpqByiWscA==
 
 dezalgo@^1.0.0:
   version "1.0.4"
@@ -7600,7 +7600,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@4.x, lodash@>=4.17.20, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.12, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -7909,7 +7909,12 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@1.2.5, minimist@>=1.2.3, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -9121,14 +9126,14 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@15.1:
-  version "15.1.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-15.1.0.tgz#5f225d7662f0f23ca49979797fc0853d23ec47a0"
-  integrity sha512-AZLQs6QB7tcYV4r7SRh8tN1OyTGI1hUBy5FDyd9Ry5wyfo1h2Tgl1uhT49sG2T8jI6JFuBXr+ratj9+zvNlx2g==
+puppeteer@14.1:
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-14.1.2.tgz#bde2ca5585fb56ed906bccced898d551778f5c5d"
+  integrity sha512-Nsyy1f7pT2KyBb15u8DHi4q3FfrIqOptAV0r4Bd1lAp2pHz8T0o4DO+On1yWZ7jFbcx1w3AqZ/e7nKqnc3Vwyg==
   dependencies:
     cross-fetch "3.1.5"
     debug "4.3.4"
-    devtools-protocol "0.0.1011705"
+    devtools-protocol "0.0.982423"
     extract-zip "2.0.1"
     https-proxy-agent "5.0.1"
     pkg-dir "4.2.0"
@@ -9137,7 +9142,7 @@ puppeteer@15.1:
     rimraf "3.0.2"
     tar-fs "2.1.1"
     unbzip2-stream "1.4.3"
-    ws "8.8.0"
+    ws "8.6.0"
 
 q@^1.5.1:
   version "1.5.1"
@@ -11266,7 +11271,12 @@ ws@8.4.2:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.2.tgz#18e749868d8439f2268368829042894b6907aa0b"
   integrity sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==
 
-ws@8.8.0, ws@>=8.7.0:
+ws@8.6.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.6.0.tgz#e5e9f1d9e7ff88083d0c0dd8281ea662a42c9c23"
+  integrity sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==
+
+ws@>=8.7.0:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.0.tgz#8e71c75e2f6348dbf8d78005107297056cb77769"
   integrity sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==


### PR DESCRIPTION
custom goto logic is more prone to errors. Should try provided defaults instead.

For puppeteer there is goto for example

For selenium(4) there is [.get](https://www.selenium.dev/documentation/webdriver/browser/navigation/#navigate-to)

By default load strategy is to wait for window to be completed but you can update strategy via [capabilities](https://www.selenium.dev/documentation/webdriver/capabilities/shared/#pageloadstrategy) 