### PR TITLE
fix: browserstack-testname-and-status

### DIFF
--- a/packages/dullahan/src/DullahanCall.ts
+++ b/packages/dullahan/src/DullahanCall.ts
@@ -52,8 +52,9 @@ const truncateRecursive = (val: unknown) => {
 }
 
 const truncateResult = (val: unknown, functionName: string) => {
-    // don't truncate the result of the screenshotPage function
-    if (functionName === 'screenshotPage') {
+    // don't truncate the result of the screenshotPage and openBrowser functions.
+    // The openBrowser result is used in packages/dullahan-plugin-browserstack/src/DullahanPluginBrowserstack.ts to create a session cache and pass test name and status to Browserstack
+    if (['screenshotPage', 'openBrowser'].includes(functionName)) {
         return val;
     }
 


### PR DESCRIPTION
Don't truncate the result of openBrowser because it's used to set the test name and status in Browserstack

<img width="784" alt="Screenshot 2022-08-01 at 22 34 34" src="https://user-images.githubusercontent.com/59452572/182398662-9b539add-683b-460a-8937-acd0c8fc1f87.png">
