### PR TITLE
fix: correct browserstackBuildUrl for Slack link

### DIFF
--- a/packages/dullahan-plugin-browserstack/src/DullahanPluginBrowserstack.ts
+++ b/packages/dullahan-plugin-browserstack/src/DullahanPluginBrowserstack.ts
@@ -123,7 +123,7 @@ export default class DullahanPluginBrowserstack extends DullahanPlugin<
                 const {automation_session} = response;
                 const {browser_url, hashed_id} = automation_session;
 
-                this.browserstackBuildUrl = browser_url.replace(`/${hashed_id}`, '');
+                this.browserstackBuildUrl = browser_url.replace(`/sessions/${hashed_id}`, '');
             }
         }
 


### PR DESCRIPTION
**Fix:**
Remove `/sessions` from the session browser_url to create a correct build url

**Description:**
The `browser_url` looked for example like this with the format `/builds/{build_id}/sessions/{hashed_id}`: https://automate.browserstack.com/builds/fb0e9da85f3d6ef2a43f3d93fd1f1171d015a4da/sessions/8e2f2cb124669676183d0efa52ec331ab6b34b8c

To create the build url we removed the `/{hashed_id}`, but the `/sessions` should also be removed 
So previously it looked like `/builds/{build_id}/sessions`
Now it will look like `/builds/{build_id}`

**What is it for?:**
To fix this browserstack link in our Slack alert channel
<img width="671" alt="Screenshot 2022-08-04 at 23 21 00" src="https://user-images.githubusercontent.com/59452572/182955043-6312ae5c-c7a4-45ee-b98d-032a5abe6d23.png">
