### PR TITLE
Revert "fix(deps): update dependency selenium-webdriver to v4.5.0"

### DIFF
--- a/packages/dullahan-adapter-selenium-4/package.json
+++ b/packages/dullahan-adapter-selenium-4/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@k2g/dullahan": "^1.0.0-alpha.154",
     "deepmerge": "^4.2.2",
-    "selenium-webdriver": "4.5.0"
+    "selenium-webdriver": "4.3.1"
   },
   "devDependencies": {
     "@types/selenium-webdriver": "^4.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9660,10 +9660,10 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-selenium-webdriver@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.5.0.tgz#7e20d0fc038177970dad81159950c12f7411ac0d"
-  integrity sha512-9mSFii+lRwcnT2KUAB1kqvx6+mMiiQHH60Y0VUtr3kxxi3oZ3CV3B8e2nuJ7T4SPb+Q6VA0swswe7rYpez07Bg==
+selenium-webdriver@4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.3.1.tgz#5e9c6c4adee65e57776b5bd4c07c59b65b8f056d"
+  integrity sha512-TjH/ls1WKRQoFEHcqtn6UtwcLnA3yvx08v9cSSFYvyhp8hJWRtbe9ae2I8uXPisEZ2EaGKKoxBZ4EHv0BJM15g==
   dependencies:
     jszip "^3.10.0"
     tmp "^0.2.1"


### PR DESCRIPTION
Reverts Kaartje2go/Dullahan#292

This seems to break runs on browserstack due to required authorization.