### PR TITLE
Improve initial load time by skipping the rendering of offscreen content

### DIFF
--- a/packages/dullahan-plugin-report-html/template/partials/styles.ejs
+++ b/packages/dullahan-plugin-report-html/template/partials/styles.ejs
@@ -73,38 +73,47 @@
         outline: none;
     }
 
+
     .section--failing details {
+        content-visibility: hidden;
         border-left-color: var(--color-failing);
     }
 
     .section--failing details[open] summary {
+        content-visibility: auto;
         background: var(--color-failing);
         color: white;
     }
 
     .section--unstable details {
+        content-visibility: hidden;
         border-left-color: var(--color-unstable);
     }
 
     .section--unstable details[open] summary {
+        content-visibility: auto;
         background: var(--color-unstable);
         color: white;
     }
 
     .section--slow details {
+        content-visibility: hidden;
         border-left-color: var(--color-slow);
     }
 
     .section--slow details[open] summary {
+        content-visibility: auto;
         background: var(--color-slow);
         color: white;
     }
 
     .section--successful details {
+        content-visibility: hidden;
         border-left-color: var(--color-successful);
     }
 
     .section--successful details[open] summary {
+        content-visibility: auto;
         background: var(--color-successful);
         color: white;
     }


### PR DESCRIPTION
This page is really big and heavy

https://web.dev/content-visibility/
