### PR TITLE
feat: implement context click

### DIFF
--- a/packages/dullahan-adapter-playwright/src/DullahanAdapterPlaywright.ts
+++ b/packages/dullahan-adapter-playwright/src/DullahanAdapterPlaywright.ts
@@ -503,7 +503,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
         });
     }
 
-    public async click(selector: string): Promise<void> {
+    public async click(selector: string, button: 'left' | 'right' = 'left'): Promise<void> {
         const {page} = this;
 
         if (!page) {
@@ -527,7 +527,7 @@ export default class DullahanAdapterPlaywright extends DullahanAdapter<DullahanA
             throw new AdapterError(DullahanErrorMessage.findElementResult(findOptions));
         }
 
-        await element.click();
+        await element.click({ button });
     }
 
     public async clickAt(x: number, y: number): Promise<void> {

--- a/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
+++ b/packages/dullahan-adapter-puppeteer/src/DullahanAdapterPuppeteer.ts
@@ -513,7 +513,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
         });
     }
 
-    public async click(selector: string): Promise<void> {
+    public async click(selector: string, button: 'left' | 'right' = 'left'): Promise<void> {
         const {page, options: {useTouch}} = this;
 
         if (!page) {
@@ -541,7 +541,7 @@ export default class DullahanAdapterPuppeteer extends DullahanAdapter<DullahanAd
             return element.tap();
         }
 
-        await element.click();
+        await element.click({ button });
     }
 
     public async clickAt(x: number, y: number): Promise<void> {

--- a/packages/dullahan/src/adapter/DullahanAdapter.ts
+++ b/packages/dullahan/src/adapter/DullahanAdapter.ts
@@ -53,7 +53,7 @@ export abstract class DullahanAdapter<
 
     public abstract clearText(selector: string, count: number): Promise<void>;
 
-    public abstract click(selector: string): Promise<void>;
+    public abstract click(selector: string, button?: 'left' | 'right'): Promise<void>;
 
     public abstract clickAt(x: number, y: number): Promise<void>;
 

--- a/packages/dullahan/src/browser_helpers/emitFakeEvent.ts
+++ b/packages/dullahan/src/browser_helpers/emitFakeEvent.ts
@@ -1,4 +1,4 @@
-type MouseEvents = 'mousedown' | 'mouseup' | 'click' | 'mousemove';
+type MouseEvents = 'mousedown' | 'mouseup' | 'click' | 'mousemove' | 'contextmenu';
 
 export type EmitFakeEventOptions = {
     type: MouseEvents;


### PR DESCRIPTION
Implement context click / right mouse button click.

This doesn't seem to be an option for Selenium 3, it also doesn't work in puppeteer with `useTouch`.